### PR TITLE
Remove Usage of gcloud (Attempt 2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM docker.io/fedora:36
 
 RUN dnf install -y --nodocs \
+    gettext \
     git \
     helm \
     jq \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ RUN mkdir -p ~/.ansible/collections/ansible_collections/google/cloud && \
   curl -sSL https://galaxy.ansible.com/download/google-cloud-1.0.2.tar.gz | tar -xzf - -C ~/.ansible/collections/ansible_collections/google/cloud && \
   mkdir -p  ~/.ansible/collections/ansible_collections/community/general && \
   curl -sSL https://galaxy.ansible.com/download/community-general-5.0.0.tar.gz | tar -xzf - -C ~/.ansible/collections/ansible_collections/community/general
+RUN curl -sSLO https://github.com/MnrGreg/kubectl-node-restart/releases/download/v1.0.6/v1.0.6.zip && \
+  python3 -c 'import zipfile ; zipfile.ZipFile("v1.0.6.zip").extractall()' && \
+  install -o root -g root -m 0755 node-restart.sh /usr/local/bin/kubectl-node-restart
 
 WORKDIR /scaffolding
 COPY . /scaffolding

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,5 @@
 FROM docker.io/fedora:36
 
-RUN mkdir -p /usr/local/gcloud && \
-  curl -sSL https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz | tar -xzf - -C /usr/local/gcloud && \
-  /usr/local/gcloud/google-cloud-sdk/install.sh \
-    --override-components='core' \
-    --override-components='kubectl' && \
-  rm -rf /usr/local/gcloud/google-cloud-sdk/.install/backup
-ENV PATH="/usr/local/gcloud/google-cloud-sdk/bin:${PATH}"
 RUN dnf install -y --nodocs \
     git \
     helm \
@@ -18,6 +11,8 @@ RUN dnf install -y --nodocs \
     ansible-core \
     google-auth \
     requests
+RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
+    install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 RUN curl -sSL https://api.github.com/repos/cloud-bulldozer/benchmark-comparison/tarball | tar -xzf - -C /opt && \
   export bc_dir=/opt/$(ls /opt | grep cloud-bulldozer-benchmark-comparison) && \
   pip install $bc_dir && \

--- a/group_vars/all
+++ b/group_vars/all
@@ -30,7 +30,6 @@ gke:
   sa_file: ".dont-share.json"
   machine_type: "n1-standard-4"
   image_type: ubuntu_containerd
-  cluster_ipv4_cidr: '10.16.0.0/14'
 
 # OpenShift Cluster Configuration for AWS
 ocp:

--- a/group_vars/all
+++ b/group_vars/all
@@ -30,6 +30,7 @@ gke:
   sa_file: ".dont-share.json"
   machine_type: "n1-standard-4"
   image_type: ubuntu_containerd
+  cluster_ipv4_cidr: '10.16.0.0/14'
 
 # OpenShift Cluster Configuration for AWS
 ocp:

--- a/roles/cilium/tasks/gke.yml
+++ b/roles/cilium/tasks/gke.yml
@@ -36,9 +36,18 @@
   copy:
     content: "{{cilium_cli_version}}"
     dest: "{{archive_dir}}/cilium_version-cli"
+- name: Get Cluster IPv4 CIDR
+  shell: |
+    export KUBECONFIG={{kubeconfig}}
+    # 'kubectl cluster-info dump' gives:
+    # <junk>--cluster-cidr=x.y.z.a\bc<junk>
+    kubectl cluster-info dump | \
+      grep -m 1 -o -E -- '--cluster-cidr=[0-9./]+' | \
+      cut -d'=' -f2
+  register: cluster_ipv4_cidr
 
 - name: Install using Cilium cli
   shell: |
       export KUBECONFIG={{kubeconfig}}
-      {{archive_dir}}/cilium install --version {{cilium_version}} --ipv4-native-routing-cidr="{{gke['cluster_ipv4_cidr']}}" {{cilium_install_params}}
+      {{archive_dir}}/cilium install --version {{cilium_version}} --ipv4-native-routing-cidr="{{cluster_ipv4_cidr.stdout}}" {{cilium_install_params}}
   when: cilium_install.rc != 0

--- a/roles/cilium/tasks/gke.yml
+++ b/roles/cilium/tasks/gke.yml
@@ -40,5 +40,5 @@
 - name: Install using Cilium cli
   shell: |
       export KUBECONFIG={{kubeconfig}}
-      {{archive_dir}}/cilium install --version {{cilium_version}} {{cilium_install_params}}
+      {{archive_dir}}/cilium install --version {{cilium_version}} --ipv4-native-routing-cidr="{{gke['cluster_ipv4_cidr']}}" {{cilium_install_params}}
   when: cilium_install.rc != 0

--- a/roles/kernel/tasks/gke.yml
+++ b/roles/kernel/tasks/gke.yml
@@ -28,14 +28,10 @@
       export KUBECONFIG={{kubeconfig}}
       kubectl rollout status ds/node-initializer
 
-  # Assumption we are logged into the account, might need to add login method to use gcloud cli
   - name: Restart GKE nodes
     shell: |
-      export GOOGLE_APPLICATION_CREDENTIALS={{ gke['sa_file']}}
-      gcloud auth activate-service-account $(cat sa.json | jq .client_email|sed 's/"//g' ) --key-file=sa.json --project $(cat sa.json | jq .project_id|sed 's/"//g' )
-      yes | gcloud config set project {{ gke['project'] }}
-      gcloud compute instances reset --zone {{ gke['region'] }} {{ item }}
-    loop: "{{ node_list.stdout_lines }}"
+      export KUBECONFIG={{kubeconfig}}
+      kubectl node restart all --force
 
   - name: Delete DS
     shell: |

--- a/roles/platform/files/get_kubeconfig.py
+++ b/roles/platform/files/get_kubeconfig.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Create kubeconfig from output of `google.cloud.gcp_container_cluster`
+
+Use `google-auth` module to get an OAuth bearer token for the given
+service account, which can then be passed to kubectl in order to
+authenticate to the cluster.
+
+References:
+* https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins
+* https://github.com/mie00/gke-kubeconfig
+* https://google-auth.readthedocs.io/en/master/user-guide.html
+
+Requires `google-auth` and `requests` to be installed.
+"""
+import argparse
+import base64
+import json
+import logging
+import os
+import shlex
+import subprocess
+import sys
+import typing as t
+
+from google.auth.transport.requests import Request
+from google.oauth2 import service_account
+
+KUBECONFIG_TEMPLATE = """
+apiVersion: v1
+kind: Config
+clusters:
+- name: gke_{cluster_name}
+  cluster:
+    server: https://{cluster_server}
+    certificate-authority-data: {cluster_ca}
+users:
+- name: my-gke-sa-user
+  user:
+    token: {user_token}
+contexts:
+- context:
+    cluster: gke_{cluster_name}
+    user: my-gke-sa-user
+  name: gke_{cluster_project}_{cluster_zone}_{cluster_name}
+current-context: gke_{cluster_project}_{cluster_zone}_{cluster_name}
+"""
+GOOGLE_AUTH_API_BASE = "https://www.googleapis.com/auth/"
+SA_MANIFEST = """
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: perfci-sa-admin
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: perfci-sa-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: perfci-sa-admin
+    namespace: kube-system
+
+"""
+
+
+def get_google_sa_token(path_to_sa: str) -> str:
+    """Use given service account private key to get token for k8s api server."""
+
+    credentials = service_account.Credentials.from_service_account_file(
+        path_to_sa,
+        scopes=[
+            GOOGLE_AUTH_API_BASE + scope
+            for scope in (
+                "userinfo.email",
+                "cloud-platform",
+                "compute",
+                "appengine.admin",
+            )
+        ],
+    )
+    credentials.refresh(Request())
+    return credentials.token
+
+
+def build_kubeconfig(
+    kubeconfig_template: str,
+    cluster_server: str,
+    cluster_name: str,
+    cluster_ca: str,
+    cluster_zone: str,
+    cluster_project: str,
+    user_token: str,
+) -> str:
+    """Use the given arguments to build a kubeconfig."""
+
+    return kubeconfig_template.format(
+        cluster_name=cluster_name,
+        cluster_server=cluster_server,
+        cluster_ca=cluster_ca,
+        cluster_zone=cluster_zone,
+        cluster_project=cluster_project,
+        user_token=user_token,
+    )
+
+
+def get_kubeconfig_params_from_gcp_container_cluster_json(
+    gcp_container_cluster_json: str,
+) -> t.Dict[str, str]:
+    """Get params for `build_kubeconfig` from `gcp_container_cluster` results."""
+
+    results = json.loads(gcp_container_cluster_json)
+    return {
+        "cluster_ca": results["masterAuth"]["clusterCaCertificate"],
+        "cluster_name": results["name"],
+        "cluster_server": results["endpoint"],
+        "cluster_zone": results["zone"],
+    }
+
+
+def run_kubectl_command(cmd: str, stdin: t.Optional[str] = None) -> str:
+    """Run the given kubectl command, assuming `set_kubeconfig`."""
+
+    cmd = "kubectl " + cmd
+    logging.info("Running '%s'", cmd)
+    try:
+        result = subprocess.run(
+            shlex.split(cmd),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            input=stdin,
+            env=os.environ,
+            timeout=20,
+            check=True,
+            text=True,
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as err:
+        logging.warning(
+            "Got error while running kubectl command '%s': %s, %s",
+            cmd,
+            err,
+            err.stdout,
+        )
+        raise
+
+    logging.info("Result: %s", result.stdout)
+    return result.stdout
+
+
+def generate_kubeconfig(
+    gke_ansible_json: str, kubeconfig_dest: str, token: str, project: str
+) -> None:
+    """Generate kubeconfig for ansible-provisioned cluster"""
+
+    logging.info(
+        "Parsing through gcp_container_cluster json: %s",
+        gke_ansible_json,
+    )
+    with open(gke_ansible_json, "r") as gke_ansible_json_file_handler:
+        gke_ansible_json = gke_ansible_json_file_handler.read()
+    kubeconfig_args = get_kubeconfig_params_from_gcp_container_cluster_json(
+        gke_ansible_json
+    )
+
+    kubeconfig_args["user_token"] = token
+    kubeconfig_args["cluster_project"] = project
+    kubeconfig = build_kubeconfig(KUBECONFIG_TEMPLATE, **kubeconfig_args)
+    with open(kubeconfig_dest, "w") as kubeconfig_file_handler:
+        kubeconfig_file_handler.write(kubeconfig)
+    logging.info("Kubeconfig written to %s", kubeconfig_dest)
+
+    os.environ["KUBECONFIG"] = kubeconfig_dest
+    run_kubectl_command("config view")
+    run_kubectl_command("get nodes")
+
+
+def create_k8s_sa() -> str:
+    """Create cluster admin SA in k8s"""
+
+    run_kubectl_command("apply -f -", stdin=SA_MANIFEST)
+    secrets = run_kubectl_command("-n kube-system get secret")
+    sa_secret = None
+    for secret in secrets.splitlines():
+        if secret.startswith("perfci-sa-admin"):
+            # Each of these entries is:
+            # 'name<w>type<w>data<w>age' where <w> is whitespace
+            sa_secret = secret.split(" ")[0].strip()
+    if sa_secret is None:
+        raise ValueError("Unable to find service account secret for 'perfci-sa-admin")
+    token_b64 = run_kubectl_command(
+        f"-n kube-system get secret {sa_secret} -o jsonpath={{.data.token}}"
+    )
+    token = base64.b64decode(token_b64).decode("utf-8")
+    return token
+
+
+def setup_logging() -> None:
+    """Configure global console logging."""
+
+    logging.basicConfig(
+        format="%(asctime)s - %(levelname)s: %(message)s",
+        level=logging.INFO,
+        stream=sys.stdout,
+    )
+
+
+def create_argument_parser() -> argparse.ArgumentParser:
+    """Create argument parser for the script."""
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "service_account_file", help="Path to private key of Google IAM service account"
+    )
+    parser.add_argument(
+        "gke_ansible_json",
+        help="File path to output of google.cloud.gcp_container_cluster",
+    )
+    parser.add_argument("kubeconfig_dest", help="Destination of kubeconfig")
+    parser.add_argument(
+        "gke_project",
+        help="Project where gke cluster is deployed",
+    )
+
+    return parser
+
+
+def main() -> None:
+
+    parser = create_argument_parser()
+    args = parser.parse_args()
+
+    setup_logging()
+
+    kubeconfig_args = {
+        "gke_ansible_json": args.gke_ansible_json,
+        "kubeconfig_dest": args.kubeconfig_dest,
+        "project": args.gke_project
+    }
+
+    logging.info("Getting token for gcp sa authentication")
+    gcp_token = get_google_sa_token(args.service_account_file)
+    generate_kubeconfig(token=gcp_token, **kubeconfig_args)
+    sa_token = create_k8s_sa()
+    generate_kubeconfig(token=sa_token, **kubeconfig_args)
+
+
+if __name__ == "__main__":
+    main()

--- a/roles/platform/tasks/gke.yml
+++ b/roles/platform/tasks/gke.yml
@@ -64,7 +64,6 @@
       name: "{{ gke_cluster_name }}"
       location: "{{ gke['region'] }}"
       project: "{{ gke['project'] }}"
-      cluster_ipv4_cidr: "{{ gke['cluster_ipv4_cidr'] }}"
       initial_node_count: "{{ num_nodes | int}}"
       node_config:
         image_type: "{{ gke['image_type'] }}"

--- a/roles/platform/tasks/gke.yml
+++ b/roles/platform/tasks/gke.yml
@@ -64,6 +64,7 @@
       name: "{{ gke_cluster_name }}"
       location: "{{ gke['region'] }}"
       project: "{{ gke['project'] }}"
+      cluster_ipv4_cidr: "{{ gke['cluster_ipv4_cidr'] }}"
       initial_node_count: "{{ num_nodes | int}}"
       node_config:
         image_type: "{{ gke['image_type'] }}"
@@ -114,13 +115,7 @@
 
   - name: Generate kubeconfig due to - https://github.com/ansible/ansible/issues/66096
     shell: |
-      export GOOGLE_APPLICATION_CREDENTIALS={{ gke['sa_file']}}
-      gcloud auth activate-service-account $(jq .client_email -r {{ gke['sa_file'] }}) --key-file={{ gke['sa_file'] }} --project $(jq .project_id -r {{ gke['sa_file'] }})
-      export KUBECONFIG={{archive_dir}}/kubeconfig
-      gcloud config set project {{ gke['project'] }}
-      gcloud config set compute/zone {{ gke['region'] }}
-      gcloud auth activate-service-account --key-file {{ gke['sa_file'] }}
-      gcloud container clusters get-credentials {{ gke_cluster_name }}
+      python3 {{role_path}}/files/get_kubeconfig.py {{gke['sa_file']}} {{archive_dir}}/cluster.json {{archive_dir}}/kubeconfig {{gke['project']}}
 
   - set_fact:
       kubeconfig: "{{archive_dir}}/kubeconfig"


### PR DESCRIPTION
In a previous attempt at removing the usage of gcloud (see #19), unexpected bugs were quickly found, causing us to have to revert the change (see #22). After taking some time, I've identified ways to address the issues we ran into. Here's what I got:

* Detect Cluster IPv4 CIDR using kubectl and pass it manually to cilium-cil, preventing the need for autodetection with gcloud CLI.
* Change the name of the context and cluster name within the generated kubeconfig to match that of the kubeconfig generated by the gcloud CLI. The cilium-cli install has certain assumptions about how the objects in the kubeconfig are specified, due to high coupling with the gcloud CLI
* Use a plugin https://github.com/MnrGreg/kubectl-node-restart to restart nodes within the kernel playbook, rather than relying on the gcloud CLI to restart nodes.