### PR TITLE
Have the benchmark role store metadata about run

### DIFF
--- a/dashboard/agent-podReady-dashboard.py
+++ b/dashboard/agent-podReady-dashboard.py
@@ -16,15 +16,24 @@ conn=databases.grab(database,es_url)
 """
 Grab all the UUIDs from the last day
 """
-uuid_query = { "query": { "range" : { "timestamp" : { "gte" : "now-3d", "lt" :  "now" } } }
-     ,"aggs": { "name": { "terms": { "field": "uuid.keyword" } } } }
+uuid_query = { "query": { "range" : { "timestamp" : { "gte" : "now-3d"  } } }}
 
 es = Elasticsearch(es_url)
 benchmark=Benchmark(open("agent-podReady-config.json"), database)
 conn=databases.grab(database,es_url)
 
-d=es.search(index="ripsaw-kube-burner",body=uuid_query)
-uuids = [value['key'] for value in d['aggregations']['name']['buckets']]
+import pprint
+
+d=es.search(index="scaffolding",body=uuid_query,size=5000)
+uuids = {}
+sizes = {}
+for id in d['hits']['hits']:
+   print(id['_source']['action'])
+   print(id['_source']['uuid'])
+   if "agent" in id['_source']['action'] :
+      uuid = id['_source']['uuid']
+      uuids[uuid] = "{}_{}".format(id['_source']['cilium_version'],id['_source']['kernel'])
+      sizes[uuid] = "{}".format(id['_source']['kernel'])
 
 row_lists=[]
 cpu_list=[]
@@ -36,26 +45,32 @@ for uuid in uuids :
                                       "uuid", uuid)
         flatten_and_discard(result,compute,row_lists)
 
-import pprint
-
-pprint.pprint(row_lists)
 latency=pd.DataFrame(data=row_lists,columns=["","metricName",
                                     "","uuid",
                                     "","name",
                                     "","result"])
 
 pprint.pprint(latency)
+pprint.pprint(row_lists)
+
+def name_run(val,meta):
+   return "{}_{}".format(meta[val],val[-4:])
+
+def size_run(val,meta):
+   return "{}_{}".format(meta[val],val[-4:])
+
+latency['run'] = latency['uuid'].apply(lambda row: name_run(row,uuids))
+latency['size'] = latency['uuid'].apply(lambda row: size_run(row,uuids))
 
 app = Dash(__name__)
-
 df = pd.pivot_table(latency,values='result',
-               index='metricName',
-               columns='uuid').to_dict()
+               index='name',
+               columns='run').to_dict()
 fig = px.bar(df,
-            x=list(df.keys()),
-            y=['Ready'],
+            y=list(df.keys()),
+            x=['Ready','Initialized','PodScheduled','ContainersReady'],
             barmode='group',
-            title="",
+            title="Pod Latency",
             )
 
 app.layout = html.Div(children=[

--- a/group_vars/all
+++ b/group_vars/all
@@ -1,6 +1,7 @@
 ---
 start_time: "{{ansible_date_time.epoch}}"
 archive_dir: /tmp/auto_perf/{{start_time}}
+scaffolding_index: scaffolding
 
 # Etiher create cluster or destroy a given cluster
 create: false

--- a/roles/benchmarks/tasks/main.yml
+++ b/roles/benchmarks/tasks/main.yml
@@ -1,4 +1,11 @@
 ---
+
+- block:
+  - name: Capture metadata
+    include_tasks: metadata.yml
+  tags:
+    - always
+
 - block:
   - name: Run datapath performance test
     include_tasks: datapath.yml

--- a/roles/benchmarks/tasks/metadata.yml
+++ b/roles/benchmarks/tasks/metadata.yml
@@ -1,0 +1,58 @@
+---
+- name: Setup kubeconfig
+  set_fact:
+    kubeconfig: "{{archive_dir}}/kubeconfig"
+  when: kubeconfig|length < 1
+
+- name: Retrieve cilium version
+  shell: |
+    export KUBECONFIG={{kubeconfig}}
+    {{archive_dir}}/cilium version | grep running | awk '{print $4}'
+  register: cilium_running_version
+
+- set_fact:
+    cilium_version: "{{ cilium_running_version.stdout }}"
+  when: test_platform is undefined
+
+- name: Retrieve k8s version
+  shell: |
+    export KUBECONFIG={{kubeconfig}}
+    kubectl version -o json| jq .serverVersion.gitVersion | sed 's/"//g'
+  register: gitversion
+
+- name: Attempt to determine platform - GKE
+  shell: |
+    export KUBECONFIG={{kubeconfig}}
+    kubectl get nodes $(kubectl get nodes -o custom-columns=:.metadata.name --no-headers) -o json | grep "gke.gcr.io"
+  register: gke_check
+  when: test_platform is undefined
+
+- set_fact:
+    test_platform: "gke"
+  when: gke_check.rc == 0
+
+- name: Retrieve region
+  shell: |
+    export KUBECONFIG={{kubeconfig}}
+    kubectl get nodes -o jsonpath="{.items[0].metadata.labels.topology\.kubernetes\.io\/region}"
+  register: region_capture
+
+- name: Retrieve kernel
+  shell: |
+    export KUBECONFIG={{kubeconfig}}
+    kubectl get nodes -o wide -o jsonpath="{.items[0].status.nodeInfo.kernelVersion}" | tee {{archive_dir}}/kernel
+  ignore_errors: true
+  register: kernel_capture
+
+- name: Retrieve instance size
+  shell: |
+    export KUBECONFIG={{kubeconfig}}
+    kubectl get nodes $(kubectl get nodes -o custom-columns=:.metadata.name --no-headers) -o jsonpath="{.items[0].metadata.labels.node\.kubernetes\.io/instance-type}"
+  ignore_errors: true
+  register: worker_size
+
+- set_fact:
+    k8s_version: "{{gitversion.stdout | default('unknown-k8s')}}"
+    kernel: "{{ kernel_capture.stdout | default('test-kernel')}}"
+    region: "{{region_capture.stdout | default('unknown-region')}}"
+    worker_size: "{{worker_size.stdout | default('unknown')}}"

--- a/roles/benchmarks/tasks/run-benchmark.yml
+++ b/roles/benchmarks/tasks/run-benchmark.yml
@@ -1,67 +1,87 @@
 ---
-  - name: Launch benchmarks
-    shell: |
-      export KUBECONFIG={{kubeconfig}}
-      kubectl create -f {{ archive_dir }}/{{item.file}}
+- name: Launch benchmarks
+  shell: |
+    export KUBECONFIG={{kubeconfig}}
+    kubectl create -f {{ archive_dir }}/{{item.file}}
 
-  - name: Wait for benchmark to complete
-    shell: |
-      export KUBECONFIG={{kubeconfig}}
-      kubectl get benchmark/{{item.name}} -n benchmark-operator -o jsonpath="{.status.complete}"
-    register: complete
-    until: complete.stdout == "true"
-    retries: 500
-    delay: 60
+- name: Wait for benchmark to complete
+  shell: |
+    export KUBECONFIG={{kubeconfig}}
+    kubectl get benchmark/{{item.name}} -n benchmark-operator -o jsonpath="{.status.complete}"
+  register: complete
+  until: complete.stdout == "true"
+  retries: 500
+  ignore_errors: true
+  delay: 60
 
-  # We will make the assumption the user did not change the name of the benchmark
-  - name: Check benchmark state
-    shell: |
-      export KUBECONFIG={{kubeconfig}}
-      kubectl get benchmark/{{item.name}} -n benchmark-operator -o jsonpath="{.status.state}"
-    register: status
+# We will make the assumption the user did not change the name of the benchmark
+- name: Check benchmark state
+  shell: |
+    export KUBECONFIG={{kubeconfig}}
+    kubectl get benchmark/{{item.name}} -n benchmark-operator -o jsonpath="{.status.state}"
+  register: status
 
-  # Consider using handler in the event it failed to complete, we clean up.
-  - fail:
-      msg: "Benchmark failed to complete"
-    when: status.stdout != "Complete"
+- set_fact:
+    benchmark_state: "{{status.stdout}}"
 
-  - name: Store console log output
-    shell: |
-      export KUBECONFIG={{kubeconfig}}
-      kubectl logs -n benchmark-operator $(kubectl get pods -n benchmark-operator -l benchmark-operator-role=client -o custom-columns=:.metadata.name --no-headers) > {{archive_dir}}/{{item.name}}.log
-    ignore_errors: true #not all benchmarks set this label (we should fix this)
+- name: Store console log output
+  shell: |
+    export KUBECONFIG={{kubeconfig}}
+    kubectl logs -n benchmark-operator $(kubectl get pods -n benchmark-operator -l benchmark-operator-role=client -o custom-columns=:.metadata.name --no-headers) > {{archive_dir}}/{{item.name}}.log
+  ignore_errors: true #not all benchmarks set this label (we should fix this)
 
-  # We will make the assumption the user did not change the name of the benchmark
-  - name: Capture run uuid
-    shell: |
-      export KUBECONFIG={{kubeconfig}}
-      kubectl get benchmarks/{{item.name}} -n benchmark-operator --no-headers -o custom-columns=:.status.uuid | tee {{archive_dir}}/{{item.name}}-uuid
-    register: uuid
+# We will make the assumption the user did not change the name of the benchmark
+- name: Capture run uuid
+  shell: |
+    export KUBECONFIG={{kubeconfig}}
+    kubectl get benchmarks/{{item.name}} -n benchmark-operator --no-headers -o custom-columns=:.status.uuid | tee {{archive_dir}}/{{item.name}}-uuid
+  register: uuid
 
-  - set_fact:
-      benchmark_uuid: "{{ uuid.stdout }}"
+- set_fact:
+    benchmark_uuid: "{{ uuid.stdout }}"
+    benchmark: "{{item.name}}"
 
-  - name: Check for run UUID
-    fail:
-      msg: "No benchmark UUID provided "
-    when: benchmark_uuid | length < 1
+- name: Check for uuid
+  fail:
+    msg: "UUID was not captured. Benchmark execution failed"
+  when: uuid|length < 1
 
-  - name: Capture results
-    shell: |
-      cp {{ role_path }}/files/uperf.json {{archive_dir}}/
-      touchstone_compare -url {{es_url}} --config {{archive_dir}}/{{item.report}} -u {{benchmark_uuid}} | tee {{archive_dir}}/{{item.name}}-result.out
-    register: report
+- name: Build metadata payload
+  template:
+    src: status.json.j2
+    dest: "{{archive_dir}}/{{benchmark}}-payload.json"
 
-  - debug:
-      var: report.stdout
+- name: Send doc to ES
+  uri:
+    url: "{{es_url}}/{{scaffolding_index}}/_doc/"
+    body: "{{ lookup('file', archive_dir + '/' + benchmark +'-payload.json') }}"
+    method: POST
+    status_code: 201
+    body_format: json
 
-  - name: Cleanup Run
-    shell: |
-      export KUBECONFIG={{kubeconfig}}
-      kubectl delete benchmark/{{item.name}} -n benchmark-operator
-    when: benchmark_cleanup
+# Consider using handler in the event it failed to complete, we clean up.
+- fail:
+    msg: "Benchmark failed to complete"
+  when: benchmark_state != "Complete"
 
-  - name : Check for uuid
-    fail:
-      msg: "UUID was not captured. Benchmark execution failed"
-    when: uuid|length < 1
+- name: Capture results
+  shell: |
+    cp {{ role_path }}/files/uperf.json {{archive_dir}}/
+    touchstone_compare -url {{es_url}} --config {{archive_dir}}/{{item.report}} -u {{benchmark_uuid}} | tee {{archive_dir}}/{{item.name}}-result.out
+  register: report
+
+- debug:
+    var: report.stdout
+
+- name: Cleanup Run
+  shell: |
+    export KUBECONFIG={{kubeconfig}}
+    kubectl delete benchmark/{{item.name}} -n benchmark-operator
+  when: benchmark_cleanup
+
+
+- name: Cleanup kube-burner namespace
+  shell: |
+    export KUBECONFIG={{kubeconfig}}
+    kubectl delete ns/pod-density-{{benchmark_uuid}}
+  when: item.name == "agent-pod-density"

--- a/roles/benchmarks/templates/agent-pod-density.yml.j2
+++ b/roles/benchmarks/templates/agent-pod-density.yml.j2
@@ -26,6 +26,9 @@ spec:
       remote_metrics_profile: {{metric_collection_url}}
       job_iterations: {{num_nodes|int*100-num_pods|int }}
       cleanup: true
+      verify_objects: true
+      error_on_verify: true
       log_level: info
       step: 30s
       qps: {{benchmark_qps | default(10)}}
+      burst: {{benchmark_qps | default(10)}}

--- a/roles/benchmarks/templates/status.json.j2
+++ b/roles/benchmarks/templates/status.json.j2
@@ -1,0 +1,13 @@
+{
+ "timestamp" : "{{ansible_date_time.iso8601}}",
+ "platform" :  "{{test_platform}}",
+ "k8version" : "{{k8s_version}}",
+ "cilium_version": "{{cilium_version}}",
+ "kernel" : "{{kernel}}",
+ "worker_size" : "{{worker_size}}",
+ "action" : "{{benchmark}}",
+ "uuid" : "{{benchmark_uuid}}",
+ "num_nodes" : "{{num_nodes}}",
+ "region" : "{{region}}",
+ "state" : "{{benchmark_state}}"
+}


### PR DESCRIPTION
We need to have a mechanism to determine *what* the benchmark SUT was at
the time of the run. Instead of having to look back at metadata, we
should have a single index which describes the SUT.

Signed-off-by: Joe Talerico <rook@isovalent.com>