### PR TITLE
Tools should be placed on a dedicated node

### DIFF
--- a/benchmark.yml
+++ b/benchmark.yml
@@ -3,4 +3,3 @@
   gather_facts: true
   roles:
   - role: benchmarks
-    tags: datapath

--- a/group_vars/all
+++ b/group_vars/all
@@ -7,6 +7,9 @@ scaffolding_index: scaffolding
 create: false
 destroy: false
 
+apply_tool_label: true
+tool_label: "scaffolding/app:tools"
+
 # Number of nodes for the initial cluster
 num_nodes: 1
 

--- a/roles/benchmarks/tasks/agent.yml
+++ b/roles/benchmarks/tasks/agent.yml
@@ -35,12 +35,6 @@
     ignore_errors: true
     register: kernel_capture
 
-  - name: Retrieve number of nodes
-    shell: |
-      export KUBECONFIG={{kubeconfig}}
-      kubectl get nodes -o wide -o jsonpath="{.items[*].status.nodeInfo.kernelVersion}" | wc -w
-    ignore_errors: true
-    register: node_count
 
   - name: Retrieve start time
     shell: |
@@ -55,7 +49,6 @@
   - set_fact:
       start_time: "{{ start_time.stdout | default('test-start')}}"
       test_platform: "{{ platform.stdout | default('test-platform')}}"
-      num_nodes: "{{node_count.stdout|int}}"
       run_id: "{{test_kernel}}-{{cilium_version}}"
       num_pods: "{{pod_count.stdout|int}}"
 
@@ -80,10 +73,20 @@
     - name: Label nodes
       shell: |
         export KUBECONFIG={{kubeconfig}}
-        for node in `kubectl get nodes -o custom-columns=:.metadata.name --no-headers`; do
+        for node in `kubectl get nodes -o custom-columns=:.metadata.name --no-headers -l "{{tool_label.split(":")[0]}} notin ({{tool_label.split(":")[1]}})"`; do
           kubectl label node/$node node-role.kubernetes.io/worker=
         done
       when: labeled_node_count.stdout|int == 0
+
+    - name: Retrieve number of nodes
+      shell: |
+        export KUBECONFIG={{kubeconfig}}
+        kubectl get nodes -o custom-columns=:.metadata.name --no-headers -l node-role.kubernetes.io/worker= | wc -l
+      ignore_errors: true
+      register: node_count
+
+    - set_fact:
+        num_workers: "{{node_count.stdout|int}}"
 
     - name: Generate agent performance benchmarks
       template:

--- a/roles/benchmarks/tasks/datapath.yml
+++ b/roles/benchmarks/tasks/datapath.yml
@@ -63,10 +63,30 @@
   - name: Label nodes
     shell: |
       export KUBECONFIG={{kubeconfig}}
-      for node in `kubectl get nodes -o custom-columns=:.metadata.name --no-headers`; do
+      for node in `kubectl get nodes -o custom-columns=:.metadata.name --no-headers -l "{{tool_label.split(":")[0]}} notin ({{tool_label.split(":")[1]}})"`; do
         kubectl label node/$node node-role.kubernetes.io/worker=
       done
     when: labeled_node_count.stdout|int == 0
+
+  - name: Check for node labels
+    shell: |
+      export KUBECONFIG={{kubeconfig}}
+      kubectl get nodes -o custom-columns=:.metadata.name --no-headers -l node-role.kubernetes.io/worker= | wc -l
+    register: node_count
+
+  - name: Determine server node (> 2 nodes)
+    shell: |
+      export KUBECONFIG={{kubeconfig}}
+      kubectl get nodes -o custom-columns=:.metadata.name --no-headers -l node-role.kubernetes.io/worker= -o jsonpath="{.items[0].metadata.name}"
+    when: node_count.stdout|int >= 2
+    register: server_node
+
+  - name: Determine client node (> 2 nodes)
+    shell: |
+      export KUBECONFIG={{kubeconfig}}
+      kubectl get nodes -o custom-columns=:.metadata.name --no-headers -l node-role.kubernetes.io/worker= -o jsonpath="{.items[1].metadata.name}"
+    when: node_count.stdout|int >= 2
+    register: client_node
 
   - name: Generate data-path performance benchmarks
     template:

--- a/roles/benchmarks/templates/agent-pod-density.yml.j2
+++ b/roles/benchmarks/templates/agent-pod-density.yml.j2
@@ -24,8 +24,10 @@ spec:
     args:
       workload: pod-density
       remote_metrics_profile: {{metric_collection_url}}
-      job_iterations: {{num_nodes|int*100-num_pods|int }}
+      job_iterations: {{num_workers|int*100-num_pods|int }}
       cleanup: true
+      jobPause: 30s
+      waitWhenFinished: true
       verify_objects: true
       error_on_verify: true
       log_level: info

--- a/roles/benchmarks/templates/datapath-uperf-rr.yml.j2
+++ b/roles/benchmarks/templates/datapath-uperf-rr.yml.j2
@@ -24,7 +24,17 @@ spec:
       serviceip: false
       networkpolicy: false
       debug: false
+{% if server_node.stdout is defined %}
+
+      pin: true
+      pin_server: {{server_node.stdout }}
+      pin_client: {{client_node.stdout }}
+
+{% else %}
+
       pin: false
+
+{% endif %}
       samples: {{ samples }}
       pair: 1
       nthrs:

--- a/roles/benchmarks/templates/datapath-uperf-stream-tcp.yml.j2
+++ b/roles/benchmarks/templates/datapath-uperf-stream-tcp.yml.j2
@@ -24,7 +24,18 @@ spec:
       serviceip: false
       networkpolicy: false
       debug: false
+{% if server_node.stdout is defined %}
+
+      pin: true
+      pin_server: {{server_node.stdout }}
+      pin_client: {{client_node.stdout }}
+
+{% else %}
+
       pin: false
+
+{% endif %}
+
       samples: {{ samples }}
       pair: 1
       nthrs:

--- a/roles/benchmarks/templates/datapath-uperf-stream-udp.yml.j2
+++ b/roles/benchmarks/templates/datapath-uperf-stream-udp.yml.j2
@@ -24,7 +24,17 @@ spec:
       serviceip: false
       networkpolicy: false
       debug: false
+{% if server_node.stdout is defined %}
+
+      pin: true
+      pin_server: {{server_node.stdout }}
+      pin_client: {{client_node.stdout }}
+
+{% else %}
+
       pin: false
+
+{% endif %}
       samples: {{ samples }}
       pair: 1
       nthrs:

--- a/roles/tools/tasks/main.yml
+++ b/roles/tools/tasks/main.yml
@@ -1,5 +1,34 @@
 ---
 
+- name: Setup kubeconfig
+  set_fact:
+    kubeconfig: "{{archive_dir}}/kubeconfig"
+  when: kubeconfig|length < 1
+  tags: prometheus,benchmark-operator,grafana
+
+- block:
+    - name : capture node count
+      shell: |
+        export KUBECONFIG={{kubeconfig}}
+        kubectl get nodes -o custom-columns=:.metadata.name --no-headers | wc -l
+      register: node_count
+
+    - debug:
+        msg: Node count is < 2, unable to isolate tools.
+      when: node_count|int <= 2
+
+    - name : Apply Scaffolding tool label to node
+      shell: |
+        export KUBECONFIG={{kubeconfig}}
+        kubectl label node $(kubectl get nodes $(kubectl get nodes -o custom-columns=:.metadata.name --no-headers) -o jsonpath="{.items[0].metadata.name}") {{tool_label|trim|replace(':','=')}} --overwrite
+      register: labeled_node
+
+    - debug:
+        msg: "{{labeled_node}}"
+
+  when: apply_tool_label
+  tags: prometheus,benchmark-operator
+
 #
 # Using Helm Install the community Prometheus
 # If Prometheus is already installed, skip
@@ -8,16 +37,16 @@
 #
 - block:
 
-  - name: Setup kubeconfig
-    set_fact:
-      kubeconfig: "{{archive_dir}}/kubeconfig"
-    when: kubeconfig|length < 1
-
   - name: Add Prometheus Helm Repo
     shell: |
       export KUBECONFIG={{kubeconfig}}
       helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
       helm repo update
+
+  - name: Generate values file
+    template:
+      src: values.yml.j2
+      dest: "{{archive_dir}}/prom-values.yml"
 
   - name: Check for existing install
     shell: |
@@ -29,8 +58,8 @@
   - name: Install Prometheus
     shell: |
       export KUBECONFIG={{kubeconfig}}
-      helm install prometheus prometheus-community/prometheus --namespace prometheus --namespace prometheus --create-namespace
-    when: prom_install.rc == 1
+      helm install prometheus prometheus-community/prometheus --namespace prometheus --namespace prometheus -f {{archive_dir}}/prom-values.yml --create-namespace 
+    when: apply_tool_label and prom_install.rc == 1
 
   - name: Check Prometheus install
     shell: |
@@ -46,11 +75,6 @@
 #
 - block:
 
-  - name: Setup kubeconfig
-    set_fact:
-      kubeconfig: "{{archive_dir}}/kubeconfig"
-    when: kubeconfig|length < 1
-
   - name: Check for existing install of Benchmark Operator
     shell: |
       export KUBECONFIG={{kubeconfig}}
@@ -58,10 +82,25 @@
     register: bmo_install
     ignore_errors: true
 
-  - name: Install Benchmark Operator
+  - name: Clean old install
+    shell: |
+      rm -rf {{archive_dir}}/bmo
+
+  - name: Copy Benchmark Operator
     shell: |
       export KUBECONFIG={{kubeconfig}}
       git clone http://github.com/cloud-bulldozer/benchmark-operator/ {{archive_dir}}/bmo
+    when: bmo_install.stdout|int == 0
+
+  - name: Generate manager manifest file
+    template:
+      src: manager.yml.j2
+      dest: "{{archive_dir}}/bmo/config/manager/manager.yaml"
+    when: bmo_install.stdout|int == 0
+
+  - name: Install Benchmark Operator
+    shell: |
+      export KUBECONFIG={{kubeconfig}}
       cd {{archive_dir}}/bmo/
       make deploy
     when: bmo_install.stdout|int == 0
@@ -86,17 +125,21 @@
 #
 - block:
 
-  - name: Setup kubeconfig
-    set_fact:
-      kubeconfig: "{{archive_dir}}/kubeconfig"
-    when: kubeconfig|length < 1
-
-  - name: Install Grafana (Performance)
+  - name: Build Grafana manifests (Performance)
     shell: |
       export KUBECONFIG={{kubeconfig}}
       git clone http://github.com/cloud-bulldozer/performance-dashboards/ {{archive_dir}}/dashboards
       cd {{archive_dir}}/dashboards
       make
+
+  - name: Generate dittybopper manifest file
+    template:
+      src: k8s-dittybopper.yaml.template.j2
+      dest: "{{archive_dir}}/dashboards/dittybopper/templates/k8s-dittybopper.yaml.template"
+
+  - name: Deploy Grafana
+    shell: |
+      export KUBECONFIG={{kubeconfig}}
       cd {{archive_dir}}/dashboards/dittybopper
       ./k8s-deploy.sh
 

--- a/roles/tools/templates/k8s-dittybopper.yaml.template.j2
+++ b/roles/tools/templates/k8s-dittybopper.yaml.template.j2
@@ -1,0 +1,622 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dittybopper
+  namespace: dittybopper
+  labels:
+    metrics-infra: dittybopper
+    name: dittybopper
+spec:
+  ports:
+  - name: dittybopper
+    port: 3000
+    protocol: TCP
+    targetPort: 3000
+  selector:
+    app: dittybopper
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: dittybopper
+  name: dittybopper
+  namespace: dittybopper
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dittybopper
+  template:
+    metadata:
+      labels:
+        app: dittybopper
+      name: dittybopper
+    spec:
+      containers:
+      - name: dittybopper
+        imagePullPolicy: Always
+        image: quay.io/cloud-bulldozer/grafana:7.3.4
+        ports:
+        - name: sc-grafana-http
+          containerPort: 3000
+        volumeMounts:
+        - mountPath: /etc/grafana
+          name: sc-grafana-config
+        - mountPath: /etc/grafana/provisioning/datasources
+          name: sc-ocp-prom
+      - name: dittybopper-syncer
+        imagePullPolicy: Always
+        env:
+        - name: GRAFANA_ADMIN_PASSWORD
+          value: ${GRAFANA_ADMIN_PASSWORD}
+        - name: DASHBOARDS
+          value: ${DASHBOARDS}
+        - name: REPOSITORY
+          value: https://github.com/cloud-bulldozer/performance-dashboards.git
+        image: quay.io/cloud-bulldozer/dittybopper-syncer:latest
+      volumes:
+      - name: sc-grafana-config
+        configMap:
+          name: sc-grafana-config
+      - name: sc-ocp-prom
+        configMap:
+          name: sc-ocp-prom
+      nodeSelector:
+        {{tool_label|trim|replace(":"," : ")}}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sc-ocp-prom
+  namespace: dittybopper
+data:
+  ocp-prometheus.yml: |
+    apiVersion: 1
+    datasources:
+    - name: Cluster Prometheus
+      type: prometheus
+      access: proxy
+      orgId: 1
+      url: ${PROMETHEUS_URL}
+      basicAuth: false
+      withCredentials: false
+      isDefault: true
+      jsonData:
+        tlsSkipVerify: true
+      version: 1
+      editable: false
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sc-grafana-config
+  namespace: dittybopper
+data:
+  grafana.ini: |
+    ##################### Grafana Configuration Example #####################
+    #
+    # Everything has defaults so you only need to uncomment things you want to
+    # change
+
+    # possible values : production, development
+    ;app_mode = production
+
+    # instance name, defaults to HOSTNAME environment variable value or hostname if HOSTNAME var is empty
+    ;instance_name = ${HOSTNAME}
+
+    #################################### Paths ####################################
+    [paths]
+    # Path to where grafana can store temp files, sessions, and the sqlite3 db (if that is used)
+    ;data = /var/lib/grafana
+
+    # Temporary files in `data` directory older than given duration will be removed
+    ;temp_data_lifetime = 24h
+
+    # Directory where grafana can store logs
+    ;logs = /var/log/grafana
+
+    # Directory where grafana will automatically scan and look for plugins
+    ;plugins = /var/lib/grafana/plugins
+
+    # folder that contains provisioning config files that grafana will apply on startup and while running.
+    ;provisioning = conf/provisioning
+
+    #################################### Server ####################################
+    [server]
+    # Protocol (http, https, socket)
+    ;protocol = http
+
+    # The ip address to bind to, empty will bind to all interfaces
+    ;http_addr =
+
+    # The http port  to use
+    ;http_port = 3000
+
+    # The public facing domain name used to access grafana from a browser
+    ;domain = localhost
+
+    # Redirect to correct domain if host header does not match domain
+    # Prevents DNS rebinding attacks
+    ;enforce_domain = false
+
+    # The full public facing url you use in browser, used for redirects and emails
+    # If you use reverse proxy and sub path specify full url (with sub path)
+    ;root_url = http://localhost:3000
+
+    # Log web requests
+    ;router_logging = false
+
+    # the path relative working path
+    ;static_root_path = public
+
+    # enable gzip
+    ;enable_gzip = false
+
+    # https certs & key file
+    ;cert_file =
+    ;cert_key =
+
+    # Unix socket path
+    ;socket =
+
+    #################################### Database ####################################
+    [database]
+    # You can configure the database connection by specifying type, host, name, user and password
+    # as separate properties or as on string using the url properties.
+
+    # Either "mysql", "postgres" or "sqlite3", it's your choice
+    ;type = sqlite3
+    ;host = 127.0.0.1:3306
+    ;name = grafana
+    ;user = root
+    # If the password contains # or ; you have to wrap it with triple quotes. Ex """#password;"""
+    ;password =
+
+    # Use either URL or the previous fields to configure the database
+    # Example: mysql://user:secret@host:port/database
+    ;url =
+
+    # For "postgres" only, either "disable", "require" or "verify-full"
+    ;ssl_mode = disable
+
+    # For "sqlite3" only, path relative to data_path setting
+    ;path = grafana.db
+
+    # Max idle conn setting default is 2
+    ;max_idle_conn = 2
+
+    # Max conn setting default is 0 (mean not set)
+    ;max_open_conn =
+
+    # Connection Max Lifetime default is 14400 (means 14400 seconds or 4 hours)
+    ;conn_max_lifetime = 14400
+
+    # Set to true to log the sql calls and execution times.
+    log_queries =
+
+    # For "sqlite3" only. cache mode setting used for connecting to the database. (private, shared)
+    ;cache_mode = private
+
+    #################################### Cache server #############################
+    [remote_cache]
+    # Either "redis", "memcached" or "database" default is "database"
+    ;type = database
+
+    # cache connectionstring options
+    # database: will use Grafana primary database.
+    # redis: config like redis server e.g. `addr=127.0.0.1:6379,pool_size=100,db=grafana`
+    # memcache: 127.0.0.1:11211
+    ;connstr =
+
+    #################################### Data proxy ###########################
+    [dataproxy]
+
+    # This enables data proxy logging, default is false
+    ;logging = false
+
+    # How long the data proxy should wait before timing out default is 30 (seconds)
+    ;timeout = 30
+
+    # If enabled and user is not anonymous, data proxy will add X-Grafana-User header with username into the request, default is false.
+    ;send_user_header = false
+
+    #################################### Analytics ####################################
+    [analytics]
+    # Server reporting, sends usage counters to stats.grafana.org every 24 hours.
+    # No ip addresses are being tracked, only simple counters to track
+    # running instances, dashboard and error counts. It is very helpful to us.
+    # Change this option to false to disable reporting.
+    reporting_enabled = false
+
+    # Set to false to disable all checks to https://grafana.net
+    # for new vesions (grafana itself and plugins), check is used
+    # in some UI views to notify that grafana or plugin update exists
+    # This option does not cause any auto updates, nor send any information
+    # only a GET request to http://grafana.com to get latest versions
+    ;check_for_updates = true
+
+    # Google Analytics universal tracking code, only enabled if you specify an id here
+    ;google_analytics_ua_id =
+
+    # Google Tag Manager ID, only enabled if you specify an id here
+    ;google_tag_manager_id =
+
+    #################################### Security ####################################
+    [security]
+    # default admin user, created on startup
+    admin_user = admin
+
+    # default admin password, can be changed before first start of grafana,  or in profile settings
+    admin_password = ${GRAFANA_ADMIN_PASSWORD}
+
+    # used for signing
+    ;secret_key = SW2YcwTIb9zpOOhoPsMm
+
+    # disable gravatar profile images
+    ;disable_gravatar = false
+
+    # data source proxy whitelist (ip_or_domain:port separated by spaces)
+    ;data_source_proxy_whitelist =
+
+    # disable protection against brute force login attempts
+    ;disable_brute_force_login_protection = false
+
+    # set to true if you host Grafana behind HTTPS. default is false.
+    ;cookie_secure = false
+
+    # set cookie SameSite attribute. defaults to `lax`. can be set to "lax", "strict" and "none"
+    ;cookie_samesite = lax
+
+    #################################### Snapshots ###########################
+    [snapshots]
+    # snapshot sharing options
+    ;external_enabled = true
+    ;external_snapshot_url = https://snapshots-origin.raintank.io
+    ;external_snapshot_name = Publish to snapshot.raintank.io
+
+    # remove expired snapshot
+    ;snapshot_remove_expired = true
+
+    #################################### Dashboards History ##################
+    [dashboards]
+    # Number dashboard versions to keep (per dashboard). Default: 20, Minimum: 1
+    ;versions_to_keep = 20
+
+    #################################### Users ###############################
+    [users]
+    # disable user signup / registration
+    ;allow_sign_up = true
+
+    # Allow non admin users to create organizations
+    ;allow_org_create = true
+
+    # Set to true to automatically assign new users to the default organization (id 1)
+    ;auto_assign_org = true
+
+    # Default role new users will be automatically assigned (if disabled above is set to true)
+    ;auto_assign_org_role = Viewer
+
+    # Background text for the user field on the login page
+    ;login_hint = email or username
+    ;password_hint = password
+
+    # Default UI theme ("dark" or "light")
+    ;default_theme = dark
+
+    # External user management, these options affect the organization users view
+    ;external_manage_link_url =
+    ;external_manage_link_name =
+    ;external_manage_info =
+
+    # Viewers can edit/inspect dashboard settings in the browser. But not save the dashboard.
+    viewers_can_edit = true
+
+    # Editors can administrate dashboard, folders and teams they create
+    ;editors_can_admin = false
+
+    [auth]
+    # Login cookie name
+    ;login_cookie_name = grafana_session
+
+    # The lifetime (days) an authenticated user can be inactive before being required to login at next visit. Default is 7 days,
+    ;login_maximum_inactive_lifetime_days = 7
+
+    # The maximum lifetime (days) an authenticated user can be logged in since login time before being required to login. Default is 30 days.
+    ;login_maximum_lifetime_days = 30
+
+    # How often should auth tokens be rotated for authenticated users when being active. The default is each 10 minutes.
+    ;token_rotation_interval_minutes = 10
+
+    # Set to true to disable (hide) the login form, useful if you use OAuth, defaults to false
+    ;disable_login_form = false
+
+    # Set to true to disable the signout link in the side menu. useful if you use auth.proxy, defaults to false
+    ;disable_signout_menu = false
+
+    # URL to redirect the user to after sign out
+    ;signout_redirect_url =
+
+    # Set to true to attempt login with OAuth automatically, skipping the login screen.
+    # This setting is ignored if multiple OAuth providers are configured.
+    ;oauth_auto_login = false
+
+    #################################### Anonymous Auth ######################
+    [auth.anonymous]
+    # enable anonymous access
+    enabled = true
+
+    # specify organization name that should be used for unauthenticated users
+    ;org_name = Main Org.
+
+    # specify role for unauthenticated users
+    ;org_role = Viewer
+
+    #################################### Github Auth ##########################
+    [auth.github]
+    ;enabled = false
+    ;allow_sign_up = true
+    ;client_id = some_id
+    ;client_secret = some_secret
+    ;scopes = user:email,read:org
+    ;auth_url = https://github.com/login/oauth/authorize
+    ;token_url = https://github.com/login/oauth/access_token
+    ;api_url = https://api.github.com/user
+    ;team_ids =
+    ;allowed_organizations =
+
+    #################################### Google Auth ##########################
+    [auth.google]
+    ;enabled = false
+    ;allow_sign_up = true
+    ;client_id = some_client_id
+    ;client_secret = some_client_secret
+    ;scopes = https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email
+    ;auth_url = https://accounts.google.com/o/oauth2/auth
+    ;token_url = https://accounts.google.com/o/oauth2/token
+    ;api_url = https://www.googleapis.com/oauth2/v1/userinfo
+    ;allowed_domains =
+
+    #################################### Generic OAuth ##########################
+    [auth.generic_oauth]
+    ;enabled = false
+    ;name = OAuth
+    ;allow_sign_up = true
+    ;client_id = some_id
+    ;client_secret = some_secret
+    ;scopes = user:email,read:org
+    ;auth_url = https://foo.bar/login/oauth/authorize
+    ;token_url = https://foo.bar/login/oauth/access_token
+    ;api_url = https://foo.bar/user
+    ;team_ids =
+    ;allowed_organizations =
+    ;tls_skip_verify_insecure = false
+    ;tls_client_cert =
+    ;tls_client_key =
+    ;tls_client_ca =
+
+    ; Set to true to enable sending client_id and client_secret via POST body instead of Basic authentication HTTP header
+    ; This might be required if the OAuth provider is not RFC6749 compliant, only supporting credentials passed via POST payload
+    ;send_client_credentials_via_post = false
+
+    #################################### Grafana.com Auth ####################
+    [auth.grafana_com]
+    ;enabled = false
+    ;allow_sign_up = true
+    ;client_id = some_id
+    ;client_secret = some_secret
+    ;scopes = user:email
+    ;allowed_organizations =
+
+    #################################### Auth Proxy ##########################
+    [auth.proxy]
+    ;enabled = false
+    ;header_name = X-WEBAUTH-USER
+    ;header_property = username
+    ;auto_sign_up = true
+    ;ldap_sync_ttl = 60
+    ;whitelist = 192.168.1.1, 192.168.2.1
+    ;headers = Email:X-User-Email, Name:X-User-Name
+
+    #################################### Basic Auth ##########################
+    [auth.basic]
+    ;enabled = true
+
+    #################################### Auth LDAP ##########################
+    [auth.ldap]
+    ;enabled = false
+    ;config_file = /etc/grafana/ldap.toml
+    ;allow_sign_up = true
+
+    #################################### SMTP / Emailing ##########################
+    [smtp]
+    ;enabled = false
+    ;host = localhost:25
+    ;user =
+    # If the password contains # or ; you have to wrap it with trippel quotes. Ex """#password;"""
+    ;password =
+    ;cert_file =
+    ;key_file =
+    ;skip_verify = false
+    ;from_address = admin@grafana.localhost
+    ;from_name = Grafana
+    # EHLO identity in SMTP dialog (defaults to instance_name)
+    ;ehlo_identity = dashboard.example.com
+
+    [emails]
+    ;welcome_email_on_sign_up = false
+
+    #################################### Logging ##########################
+    [log]
+    # Either "console", "file", "syslog". Default is console and  file
+    # Use space to separate multiple modes, e.g. "console file"
+    ;mode = console file
+
+    # Either "debug", "info", "warn", "error", "critical", default is "info"
+    ;level = info
+
+    # optional settings to set different levels for specific loggers. Ex filters = sqlstore:debug
+    ;filters =
+
+    # For "console" mode only
+    [log.console]
+    ;level =
+
+    # log line format, valid options are text, console and json
+    ;format = console
+
+    # For "file" mode only
+    [log.file]
+    ;level =
+
+    # log line format, valid options are text, console and json
+    ;format = text
+
+    # This enables automated log rotate(switch of following options), default is true
+    ;log_rotate = true
+
+    # Max line number of single file, default is 1000000
+    ;max_lines = 1000000
+
+    # Max size shift of single file, default is 28 means 1 << 28, 256MB
+    ;max_size_shift = 28
+
+    # Segment log daily, default is true
+    ;daily_rotate = true
+
+    # Expired days of log file(delete after max days), default is 7
+    ;max_days = 7
+
+    [log.syslog]
+    ;level =
+
+    # log line format, valid options are text, console and json
+    ;format = text
+
+    # Syslog network type and address. This can be udp, tcp, or unix. If left blank, the default unix endpoints will be used.
+    ;network =
+    ;address =
+
+    # Syslog facility. user, daemon and local0 through local7 are valid.
+    ;facility =
+
+    # Syslog tag. By default, the process' argv[0] is used.
+    ;tag =
+
+    #################################### Alerting ############################
+    [alerting]
+    # Disable alerting engine & UI features
+    ;enabled = true
+    # Makes it possible to turn off alert rule execution but alerting UI is visible
+    ;execute_alerts = true
+
+    # Default setting for new alert rules. Defaults to categorize error and timeouts as alerting. (alerting, keep_state)
+    ;error_or_timeout = alerting
+
+    # Default setting for how Grafana handles nodata or null values in alerting. (alerting, no_data, keep_state, ok)
+    ;nodata_or_nullvalues = no_data
+
+    # Alert notifications can include images, but rendering many images at the same time can overload the server
+    # This limit will protect the server from render overloading and make sure notifications are sent out quickly
+    ;concurrent_render_limit = 5
+
+
+    # Default setting for alert calculation timeout. Default value is 30
+    ;evaluation_timeout_seconds = 30
+
+    # Default setting for alert notification timeout. Default value is 30
+    ;notification_timeout_seconds = 30
+
+    # Default setting for max attempts to sending alert notifications. Default value is 3
+    ;max_attempts = 3
+
+    #################################### Explore #############################
+    [explore]
+    # Enable the Explore section
+    ;enabled = true
+
+    #################################### Internal Grafana Metrics ##########################
+    # Metrics available at HTTP API Url /metrics
+    [metrics]
+    # Disable / Enable internal metrics
+    ;enabled           = true
+
+    # Publish interval
+    ;interval_seconds  = 10
+
+    # Send internal metrics to Graphite
+    [metrics.graphite]
+    # Enable by setting the address setting (ex localhost:2003)
+    ;address =
+    ;prefix = prod.grafana.%(instance_name)s.
+
+    #################################### Distributed tracing ############
+    [tracing.jaeger]
+    # Enable by setting the address sending traces to jaeger (ex localhost:6831)
+    ;address = localhost:6831
+    # Tag that will always be included in when creating new spans. ex (tag1:value1,tag2:value2)
+    ;always_included_tag = tag1:value1
+    # Type specifies the type of the sampler: const, probabilistic, rateLimiting, or remote
+    ;sampler_type = const
+    # jaeger samplerconfig param
+    # for "const" sampler, 0 or 1 for always false/true respectively
+    # for "probabilistic" sampler, a probability between 0 and 1
+    # for "rateLimiting" sampler, the number of spans per second
+    # for "remote" sampler, param is the same as for "probabilistic"
+    # and indicates the initial sampling rate before the actual one
+    # is received from the mothership
+    ;sampler_param = 1
+
+    #################################### Grafana.com integration  ##########################
+    # Url used to import dashboards directly from Grafana.com
+    [grafana_com]
+    ;url = https://grafana.com
+
+    #################################### External image storage ##########################
+    [external_image_storage]
+    # Used for uploading images to public servers so they can be included in slack/email messages.
+    # you can choose between (s3, webdav, gcs, azure_blob, local)
+    ;provider =
+
+    [external_image_storage.s3]
+    ;bucket =
+    ;region =
+    ;path =
+    ;access_key =
+    ;secret_key =
+
+    [external_image_storage.webdav]
+    ;url =
+    ;public_url =
+    ;username =
+    ;password =
+
+    [external_image_storage.gcs]
+    ;key_file =
+    ;bucket =
+    ;path =
+
+    [external_image_storage.azure_blob]
+    ;account_name =
+    ;account_key =
+    ;container_name =
+
+    [external_image_storage.local]
+    # does not require any configuration
+
+    [rendering]
+    # Options to configure external image rendering server like https://github.com/grafana/grafana-image-renderer
+    ;server_url =
+    ;callback_url =
+
+    [enterprise]
+    # Path to a valid Grafana Enterprise license.jwt file
+    ;license_path =
+
+    [panels]
+    # If set to true Grafana will allow script tags in text panels. Not recommended as it enable XSS vulnerabilities.
+    ;disable_sanitize_html = false
+
+    [plugins]
+    ;enable_alpha = false
+    ;app_tls_skip_verify_insecure = false

--- a/roles/tools/templates/manager.yml.j2
+++ b/roles/tools/templates/manager.yml.j2
@@ -1,0 +1,88 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: operator
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+  labels:
+    control-plane: controller-manager
+spec:
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+    spec:
+      securityContext:
+        runAsNonRoot: true
+      containers:
+      - name: manager
+        args:
+        - --leader-elect
+        - --leader-election-id=ripsaw
+        image: controller:latest
+        imagePullPolicy: Always
+        env:
+        - name: ANSIBLE_GATHERING
+          value: explicit
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: OPERATOR_NAME
+          value: "benchmark-operator"
+        - name: MAX_CONCURRENT_RECONCILES_BENCHMARK_RIPSAW_CLOUDBULLDOZER_IO
+          value: "4"
+        - name: ANSIBLE_VERBOSITY_BENCHMARK_RIPSAW_CLOUDBULLDOZER_IO
+          value: "4"
+        securityContext:
+          allowPrivilegeEscalation: false
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 6789
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 6789
+          initialDelaySeconds: 5
+          periodSeconds: 10
+      - name: redis-master
+        image: bitnami/redis:6.2.7
+        env:
+          - name: MASTER
+            value: "true"
+          - name: ALLOW_EMPTY_PASSWORD
+            value: "yes"
+        ports:
+          - containerPort: 6379
+        resources:
+          requests:
+            cpu: "100m"
+          limits:
+            cpu: "2.0"
+        volumeMounts:
+          - mountPath: /redis-master-data
+            name: data
+      serviceAccountName: operator
+      terminationGracePeriodSeconds: 10
+      volumes:
+        - name: data
+          emptyDir: {}
+      nodeSelector:
+        {{tool_label|trim|replace(":"," : ")}}

--- a/roles/tools/templates/values.yml.j2
+++ b/roles/tools/templates/values.yml.j2
@@ -1,0 +1,15 @@
+alertmanager:
+   nodeSelector:
+     {{tool_label|trim|replace(":"," : ")}}
+kube-state-metrics:
+   nodeSelector:
+     {{tool_label|trim|replace(":"," : ")}}
+kubestatemetrics:
+   nodeSelector:
+     {{tool_label|trim|replace(":"," : ")}}
+server:
+   nodeSelector:
+     {{tool_label|trim|replace(":"," : ")}}
+pushgateway:
+   nodeSelector:
+     {{tool_label|trim|replace(":"," : ")}}


### PR DESCRIPTION
To reduce noise in the benchmark results we should steer tool pods to a
dedicated node. Currently we use a single node for tools, eventually we
might want to consider having more tool/infra nodes.

In testing we should always deploy at least 3 nodes,
- 1 infra/tool node
- 2 workload nodes

The current scripts still will label a single node even if the user
deploys < 3 nodes.

fixes #27

Signed-off-by: Joe Talerico <rook@isovalent.com>