### PR TITLE
podDensity workload with multiple samples

### DIFF
--- a/roles/benchmarks/tasks/agent.yml
+++ b/roles/benchmarks/tasks/agent.yml
@@ -88,16 +88,25 @@
     - set_fact:
         num_workers: "{{node_count.stdout|int}}"
 
+    - set_fact:
+        podDensity_uuid: "{{ (999999999999999999999 | random | string + (lookup('pipe', 'date +%s%N'))) | to_uuid() | string }}"
+
+    - set_fact:
+        podDensity: "{{ podDensity|default([]) + [ {'file': 'agent-pod-density.yml.j2','name': 'agent-pod-density-'+item|string+'.yml','report': 'pod-density.json'} ] }}"
+      loop: "{{ range(0, samples,1)|list }}"
+
     - name: Generate agent performance benchmarks
       template:
         src: "{{item.file}}"
         dest: "{{archive_dir}}/{{item.name}}"
-      with_items:
-        - { file: agent-pod-density.yml.j2, name: agent-pod-density.yml }
+      with_items: "{{ podDensity }}"
+
+    - set_fact:
+        podDensityBenchmarks: "{{ podDensityBenchmarks|default([]) + [ {'name': 'agent-pod-density', 'file': 'agent-pod-density-'+item|string+'.yml','report': 'pod-density.json'} ] }}"
+      loop: "{{ range(0, samples,1)|list }}"
 
     - name: Run agent benchmarks
       include_tasks: run-benchmark.yml
-      with_items:
-        - {name: agent-pod-density, file: agent-pod-density.yml, report: pod-density.json}
+      with_items: "{{ podDensityBenchmarks }}"
 
   when: bmo.rc == 0

--- a/roles/benchmarks/tasks/run-benchmark.yml
+++ b/roles/benchmarks/tasks/run-benchmark.yml
@@ -67,7 +67,7 @@
 - name: Capture results
   shell: |
     cp {{ role_path }}/files/uperf.json {{archive_dir}}/
-    touchstone_compare -url {{es_url}} --config {{archive_dir}}/{{item.report}} -u {{benchmark_uuid}} | tee {{archive_dir}}/{{item.name}}-{{run_id}}-result.out
+    touchstone_compare -url {{es_url}} --config {{archive_dir}}/{{item.report}} -u {{benchmark_uuid}} | tee {{archive_dir}}/{{item.name}}-{{run_id}}-{{item.file}}-result.out
   register: report
 
 - debug:

--- a/roles/benchmarks/templates/agent-pod-density.yml.j2
+++ b/roles/benchmarks/templates/agent-pod-density.yml.j2
@@ -4,6 +4,7 @@ metadata:
   name: agent-pod-density
   namespace: benchmark-operator
 spec:
+  uuid: {{ podDensity_uuid }}
   metadata:
     collection: true
     targeted: false


### PR DESCRIPTION
The `samples` var was only being applied to the datapath workload. This
patch allows for multiple samples of the agent podDensity workload.

Signed-off-by: Joe Talerico <rook@isovalent.com>