### PR TITLE
Adding parcadev and fixing metrics

### DIFF
--- a/metrics/system-metrics.yml
+++ b/metrics/system-metrics.yml
@@ -72,7 +72,7 @@
   metricName: alerts
 
 # Cilium specific metrics
-- query: avg(histogram_quantile(0.90, rate(cilium_endpoint_regeneration_time_stats_seconds_bucket{k8s_app="cilium", scope!="total"}[5m]))) by (scope)"
+- query: avg(histogram_quantile(0.90, rate(cilium_endpoint_regeneration_time_stats_seconds_bucket{k8s_app="cilium", scope!="total"}[5m]))) by (scope)
   metricName: ciliumEndpointRegeneration
  
 - query: cilium_bpf_maps_virtual_memory_max_bytes{k8s_app="cilium"} + cilium_bpf_progs_virtual_memory_max_bytes{k8s_app="cilium"}

--- a/roles/cilium/tasks/gke.yml
+++ b/roles/cilium/tasks/gke.yml
@@ -40,5 +40,5 @@
 - name: Install using Cilium cli
   shell: |
       export KUBECONFIG={{kubeconfig}}
-      {{archive_dir}}/cilium install --version {{cilium_version}} {{cilium_install_params}}
+      {{archive_dir}}/cilium install --version {{cilium_version}} {{cilium_install_params}} --helm-set prometheus.enabled=true --helm-set operator.prometheus.enabled=true
   when: cilium_install.rc != 0

--- a/roles/tools/tasks/main.yml
+++ b/roles/tools/tasks/main.yml
@@ -28,6 +28,41 @@
 
   when: apply_tool_label | bool
   tags: prometheus,benchmark-operator
+#
+# Using Helm Install the community Parca Dev
+# If Parca is already installed, skip
+#
+- block:
+    - name: Add Parca Dev Helm Repo
+      shell: |
+        export KUBECONFIG={{kubeconfig}}
+        helm repo add parca https://parca-dev.github.io/helm-charts/
+        helm repo update
+
+    - name: Generate parca values file
+      template:
+        src: parca-values.yml.j2
+        dest: "{{archive_dir}}/parca-values.yml"
+
+    - name: Check for existing install
+      shell: |
+        export KUBECONFIG={{kubeconfig}}
+        helm status -n parca my-parca | grep deployed
+      register: parca_install
+      ignore_errors: true
+
+    - name: Install ParcaDev
+      shell: |
+        export KUBECONFIG={{kubeconfig}}
+        helm install my-parca parca/parca -n parca -f {{archive_dir}}/parca-values.yml --create-namespace
+      when: parca_install.rc == 1
+
+    - name: Check ParcaDev install
+      shell: |
+        export KUBECONFIG={{kubeconfig}}
+        helm status -n parca my-parca | grep deployed
+      when: parca_install.rc == 1
+  tags: parcadev
 
 #
 # Using Helm Install the community Prometheus
@@ -58,7 +93,7 @@
   - name: Install Prometheus
     shell: |
       export KUBECONFIG={{kubeconfig}}
-      helm install prometheus prometheus-community/prometheus --namespace prometheus --namespace prometheus -f {{archive_dir}}/prom-values.yml --create-namespace 
+      helm install prometheus prometheus-community/prometheus --namespace prometheus --namespace prometheus -f {{archive_dir}}/prom-values.yml --create-namespace
     when: apply_tool_label and prom_install.rc == 1
 
   - name: Check Prometheus install

--- a/roles/tools/templates/parca-values.yml.j2
+++ b/roles/tools/templates/parca-values.yml.j2
@@ -1,0 +1,3 @@
+server:
+    nodeSelector:
+         {{tool_label|trim|replace(":"," : ")}}


### PR DESCRIPTION
- Adding parcadev so users can pass the tag `parcadev` to install that
  tool. It will follow the same convention of installing the server
  aspects on a single node (non workload node)
- noticed issues with the metric collection (rogue quote)
- we collect cilium metrics, so we need to enable them by default at
  install time

Signed-off-by: Joe Talerico <rook@isovalent.com>