### PR TITLE
Add Scope Variable to Metadata

### DIFF
--- a/ci/matrix.jsonnet
+++ b/ci/matrix.jsonnet
@@ -10,7 +10,8 @@ local UNI_PARAMS = {
     'gke': {
         'sa_file': '/tmp/workspace/sa.json'
     },
-    'auth': true
+    'auth': true,
+    'scope': 'circleci'
 };
 local create_matrix_item(cilium_version, kernel) = {
     'cilium_version': cilium_version,

--- a/roles/benchmarks/templates/status.json.j2
+++ b/roles/benchmarks/templates/status.json.j2
@@ -9,5 +9,6 @@
  "uuid" : "{{benchmark_uuid}}",
  "num_nodes" : "{{num_nodes}}",
  "region" : "{{region}}",
- "state" : "{{benchmark_state}}"
+ "state" : "{{benchmark_state}}",
+ "scope": "{{scope}}"
 }

--- a/roles/benchmarks/templates/status.json.j2
+++ b/roles/benchmarks/templates/status.json.j2
@@ -10,5 +10,5 @@
  "num_nodes" : "{{num_nodes}}",
  "region" : "{{region}}",
  "state" : "{{benchmark_state}}",
- "scope": "{{scope}}"
+ "scope": "{{ (scope is not defined or scope == '') | ternary('manual', scope) }}"
 }


### PR DESCRIPTION
Adds a new variable `scope` which can be set to any string, allowing for easier filtering in ES result data.

Turns out I accidentally included the `scope` variable in `group_vars/all` in #41, which is why it's not present here.