### PR TITLE
Add pushgateway kustomize template.

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,8 +152,9 @@ Structured as a collection of bases that can be combined as needed. Just using t
 
 * [prometheus-operator](https://github.com/prometheus-operator/prometheus-operator)
 * prometheus (using prometheus operator) on any node labeled `role.scaffolding/monitoring=true`, attached to a service named `prometheus`.
-* [node-exporter](https://github.com/prometheus/node_exporter) on any node labeled `role.scaffolding/monitored=true`
-* [cadvisor](https://github.com/google/cadvisor) on any node labeled `role.scaffolding/monitored=true`
+* [node-exporter](https://github.com/prometheus/node_exporter) on any node labeled `role.scaffolding/monitored=true`.
+* [cadvisor](https://github.com/google/cadvisor) on any node labeled `role.scaffolding/monitored=true`.
+* [pushgateway](https://github.com/prometheus/pushgateway) on any node labeled `role.scaffolding/monitored=true`, attached to a service named `pushgateway`. A ServiceMonitor is included.
 
 ### grafana
 

--- a/kustomize/prometheus/pushgateway/kustomization.yaml
+++ b/kustomize/prometheus/pushgateway/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: monitoring
 resources:
-- prometheus
-- node-exporter
-- cadvisor
-- pushgateway
+- pushgateway.yaml
+- service.yaml
+- service-monitor.yaml

--- a/kustomize/prometheus/pushgateway/pushgateway.yaml
+++ b/kustomize/prometheus/pushgateway/pushgateway.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: pushgateway
+  name: pushgateway
+spec:
+  selector:
+    matchLabels:
+      app: pushgateway
+  template:
+    metadata:
+      labels:
+        app: pushgateway
+    spec:
+      nodeSelector:
+        role.scaffolding/monitoring: "true"
+      containers:
+        - name: pushgateway
+          image: prom/pushgateway
+          ports:
+            - containerPort: 9091
+              name: http-pg
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: http-pg
+              scheme: HTTP
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: http-pg
+              scheme: HTTP

--- a/kustomize/prometheus/pushgateway/service-monitor.yaml
+++ b/kustomize/prometheus/pushgateway/service-monitor.yaml
@@ -1,0 +1,11 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: pushgateway
+spec:
+  selector:
+    matchLabels:
+      app: pushgateway
+  endpoints:
+  - port: http-pg
+    honorLabels: true

--- a/kustomize/prometheus/pushgateway/service.yaml
+++ b/kustomize/prometheus/pushgateway/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: pushgateway
+  labels:
+    app: pushgateway
+spec:
+  ports:
+    - port: 9091
+      protocol: TCP
+      targetPort: http-pg
+      name: http-pg
+  selector:
+    app: pushgateway
+  sessionAffinity: None


### PR DESCRIPTION
By adding a pushgateway to the cluster, custom prometheus metrics can be exported for benchmark results. Say I have the following output from netperf (cut for length):

```text
Wed Aug 10 10:08:04 AM MDT 2022
MIGRATED TCP STREAM TEST from 0.0.0.0 (0.0.0.0) port ....
THROUGHPUT=2687.23
THROUGHPUT_UNITS=10^6bits/s
ELAPSED_TIME=60.01
```

These metrics can be imported into prometheus as desired by making curl requests to the pushgateway's `/metrics` endpoint:

```bash
kubectl port-forward -n monitoring svc/pushgateway 9091:9091
export labels="job/mytest/instance/netperf/type/tcp_stream"
curl -X PUT \
    --data-binary @my-metrics \
    localhost:9091/metrics/"${labels}"
```

Where `my-metrics` looks something like this:

```text
# TYPE netperf_throughput_total_bytes counter
netperf_throughput_total_bytes 20154225000.0
# TYPE netperf_elapsed_time_seconds counter
netperf_elapsed_time_seconds 60.01
```

netperf_throughput_total_bytes calculated as:

`(throughput_bits_1E6 * duration_s) * (1E6) / 8`

Here's a link for how this text-based format works:

* https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md

More scripts can be added to help easily parse results from netperf and other micro-benchmarks into prometheus metrics. It might also be useful to add something like this into toolkit, but personally I think using a template approach with curl would be the path of least resistance.

These are some helpful resources on writing metrics into prom:

* https://prometheus.io/docs/practices/naming/#metric-and-label-naming
* https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/clientlibs.md

Signed-off-by: Ryan Drew <ryan.drew@isovalent.com>