### PR TITLE
Set hostNetwork: true in node-exporter ds

### DIFF
--- a/kustomize/node-exporter/daemonset.yaml
+++ b/kustomize/node-exporter/daemonset.yaml
@@ -17,6 +17,7 @@ spec:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/name: node-exporter
     spec:
+      hostNetwork: true
       nodeSelector:
         role.scaffolding/monitored: "true"
       containers:


### PR DESCRIPTION
This commit configures node-exporter pods in the node-exporter daemonset to be set to the host network, allowing for the host's network metrics te be recorded rather than the node-exporter pod's network metrics to be recorded.

For more information: https://stackoverflow.com/questions/62606739/network-transfer-speeds-in-mb-s-using-prometheus-grafana

Signed-off-by: Ryan Drew <ryan.drew@isovalent.com>