### PR TITLE
Add GKE-specific conditions to toolkit

### DIFF
--- a/toolkit/toolkit/k8s/verify.go
+++ b/toolkit/toolkit/k8s/verify.go
@@ -69,7 +69,9 @@ func DoesConditionShowReady(condition map[string]interface{}) (bool, error) {
 	switch ct {
 	case "Ready", "Initialized", "ContainersReady", "PodScheduled", "Progressing", "Available":
 		return cs == string(v1.ConditionTrue), nil
-	case "MemoryPressure", "DiskPressure", "PIDPressure", "NetworkUnavailable":
+	case "MemoryPressure", "DiskPressure", "PIDPressure", "NetworkUnavailable", "FrequentDockerRestart",
+		"FrequentContainerdRestart", "KernelDeadlock", "ReadonlyFilesystem", "CorruptDockerOverlay2",
+		"FrequentUnregisterNetDevice", "FrequentKubeletRestart":
 		return cs == string(v1.ConditionFalse), nil
 	default:
 		return false, fmt.Errorf("unknown condition: %s", ct)


### PR DESCRIPTION
This commit adds conditions from GKE into `toolkit/k8s/verify.go` to fix toolkit's `verify k8s-ready` commnad failing on GKE.

Signed-off-by: Ryan Drew <ryan.drew@isovalent.com>