### PR TITLE
Add to scenarios/common.sh

### DIFF
--- a/scenarios/common.sh
+++ b/scenarios/common.sh
@@ -1,18 +1,32 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-echo "importing the following from $(basename $0):"
+# init function for main scripts in scenarios, does the following:
+# - set environment variables for locations to different directories
+#   in the repo
+# - create artifacts directory
+# - ensure toolkit is in artifacts directory
+init() {
+    SCENARIO_DIR=$(pwd)
+    ROOT_DIR=$(realpath ../../)
+    TOOLKIT=$ROOT_DIR/toolkit
+    SCRIPT=$ROOT_DIR/scripts
+    IMAGE=$ROOT_DIR/images
+    KUSTOMIZE=$ROOT_DIR/kustomize
+    ARTIFACTS=$SCENARIO_DIR/artifacts
 
-SCENARIO_DIR=$(pwd)
-ROOT_DIR=$(realpath ../../)
-TOOLKIT=$ROOT_DIR/toolkit
-SCRIPT=$ROOT_DIR/scripts
-IMAGE=$ROOT_DIR/images
-KUSTOMIZE=$ROOT_DIR/kustomize
-ARTIFACTS=$SCENARIO_DIR/artifacts
+    mkdir -p $ARTIFACTS
+    if ! test -f "$ARTIFACTS/toolkit"
+    then
+        build_toolkit
+    fi
+}
 
-echo "---  env vars ---"
-cat <<EOF
+# print what is imported from this script
+init_print() {
+    cat <<EOF
+importing the following from common.sh
+--- env vars ---
 SCENARIO_DIR=$SCENARIO_DIR
 ROOT_DIR=$ROOT_DIR
 TOOLKIT=$TOOLKIT
@@ -20,32 +34,30 @@ SCRIPT=$SCRIPT
 IMAGE=$IMAGE
 KUSTOMIZE=$KUSTOMIZE
 ARTIFACTS=$ARTIFACTS
+--- functions ---
+build_toolkit
+wait_ready
+breakpoint
 EOF
+}
 
-echo "--- functions ---"
-echo "build_toolkit"
-echo "wait_ready"
-echo "breakpoint"
 
 # build toolkit bin
 build_toolkit() {
     cd $TOOLKIT
-    go build -o $ARTIFACTS/toolkitbin .
+    go build -o $ARTIFACTS/toolkit .
     cd $SCENARIO_DIR
 }
 
 # wait for cluster to be ready to go
-wait_ready () {
-    $SCRIPT/retry.sh 5 $SCRIPT/k8s-api-readyz.sh
-    $SCRIPT/retry.sh 5 $ARTIFACTS/toolkitbin verify k8s-ready
+wait_ready() {
+    $SCRIPT/retry.sh 5 $SCRIPT/k8s_api_readyz.sh
+    $SCRIPT/retry.sh 5 $ARTIFACTS/toolkit verify k8s-ready
 }
 
 
 # wait for user input
-breakpoint () {
+breakpoint() {
     read  -n 1 -p "press key to continue..."
     echo
 }
-
-mkdir -p $ARTIFACTS
-set -x

--- a/scenarios/common.sh
+++ b/scenarios/common.sh
@@ -38,6 +38,7 @@ ARTIFACTS=$ARTIFACTS
 build_toolkit
 wait_ready
 breakpoint
+add_env_var_or_die
 EOF
 }
 
@@ -60,4 +61,15 @@ wait_ready() {
 breakpoint() {
     read  -n 1 -p "press key to continue..."
     echo
+}
+
+# check env variable is set
+env_var_or_die() {
+    if [[ -z "${!1}" ]]
+    then
+        echo "$1 must be set to continue"
+        exit 1
+    else
+        echo "$1: ${!1}"
+    fi
 }

--- a/scenarios/xdp/xdp.sh
+++ b/scenarios/xdp/xdp.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
-set -eo pipefail
+set -xeo pipefail
 
 # Env and common functions
 . ../common.sh
+init
+init_print
 
 # don't do a connectivity test for cilium 
 SKIP_CT=""
@@ -11,10 +13,6 @@ then
     SKIP_CT="skip-ct"
     shift 1
 fi
-
-# build the golang toolkit bin, which will be used to verify
-# k8s pods and nodes are ready
-build_toolkit
 
 # get cilium cli for install/status
 if ! [ -f "$ARTIFACTS/cilium" ]

--- a/scenarios/xdp/xdp.sh
+++ b/scenarios/xdp/xdp.sh
@@ -139,19 +139,6 @@ install_cilium_kpr_xdp() {
     ensure_strict_kpr
 }
 
-# wait for cilium to be ready and then run a connectivity test
-wait_cilium_ready() {
-    wait_ready
-    $ARTIFACTS/cilium status --wait --wait-duration=1m
-
-
-    if [ "$SKIP_CT" != "skip-ct" ]
-    then   
-        $ARTIFACTS/cilium connectivity test
-        kubectl delete ns cilium-test
-    fi
-}
-
 # install metallb l2 load balancer
 # this probably won't apply to all environments, so adjust if needed
 install_metallb() {

--- a/scenarios/xdp/xdp.sh
+++ b/scenarios/xdp/xdp.sh
@@ -142,7 +142,7 @@ install_cilium_kpr_xdp() {
 # install metallb l2 load balancer
 # this probably won't apply to all environments, so adjust if needed
 install_metallb() {
-    kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.4/config/manifests/metallb-native.yaml
+    kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.6/config/manifests/metallb-native.yaml
     wait_ready
     kubectl apply -f $SCENARIO_DIR/metallb_l2.yaml
 }


### PR DESCRIPTION
This PR introduces a couple of changes to common.sh. Please see commits for more details, but here is the gist (tm)

* The main idea with common.sh is that it provides common enviromnent variables and functions for other scripts. Previously, when common.sh was sourced, it set a bunch of environment variables and then dumped a whole bunch of output on what the values of those variables are and on what functions it is importing. I've split this up into two functions (`init` and `init_print`) to make common.sh more consumable from smaller, non-main scripts.
* The toolkit binary is now built during the `init` function as a convenience. It's built to `$ARTIFACTS/toolkit` now rather than `$ARTIFACTS/toolkitbin`, which was confusing.
* Adds `env_var_or_die`, which checks if a variable is set and exits if it isn't.
* Moves `wait_cilium_ready` from `scenarios/xdp.sh` into `common.sh`, as this is useful enough to be consumed by other scripts.

When updating `scenarios/xdp.sh` to account for these breaking changes, I found that metallb wasn't installing successfully. The last commit in this PR bumps the metallb version to fix this.