### PR TITLE
Add node-exporter to kustomization.yaml in xdp

### DIFF
--- a/scenarios/xdp/kustomization.yaml
+++ b/scenarios/xdp/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../kustomize/prometheus
+- ../../kustomize/node-exporter
 - ../../kustomize/grafana
 - ../../kustomize/topologies/pod2pod/overlays/service
 patchesStrategicMerge:


### PR DESCRIPTION
The node-exporter kustomize manifests used to be part of the prometheus kustomize manifests, but were moved out as part of https://github.com/cilium/scaffolding/commit/b6c4a02827212bf70c5fa38604a0674c7863752a. This change was not propagated to xdp's kustomization.yaml.

Signed-off-by: Ryan Drew <ryan.drew@isovalent.com>