### PR TITLE
Add monitoring-ns kustomization manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,12 @@ Three dashboards are provided out-of-the-box in `kustomize/grafana/dashboards`, 
 
 A dashboard provider is used to accomplish this. See the [grafana docs](https://grafana.com/docs/grafana/latest/administration/provisioning/#dashboards) for more information.
 
+### monitoring-ns
+
+Creates a namespace named 'monitoring'.
+Kustomize doesn't auto-create namespaces, so something needs to create the 'monitoring' ns for resources like prometheus and grafana (see above).
+By including this manifest, you won't have to manually create the namespace before a `kustomize build | kubectl apply -f -`.
+
 ### registry
 
 Deploys an in-cluster registry in the namespace `registry`, available through the service named `registry`.

--- a/kustomize/monitoring-ns/kustomization.yaml
+++ b/kustomize/monitoring-ns/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml

--- a/kustomize/monitoring-ns/namespace.yaml
+++ b/kustomize/monitoring-ns/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring


### PR DESCRIPTION
Kustomize does not auto-create namespaces- this feature was removed due to https://github.com/kubernetes-sigs/kustomize/issues/514. The monitoring-ns resource can be included in kustomizations that also include other monitoring resources, such as prometheus and grafana, to avoid boilerplate involved in creating the namespace manually.

Signed-off-by: Ryan Drew <ryan.drew@isovalent.com>