### PR TITLE
Add info on node-exporter to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,14 @@ Three dashboards are provided out-of-the-box in `kustomize/grafana/dashboards`, 
 
 A dashboard provider is used to accomplish this. See the [grafana docs](https://grafana.com/docs/grafana/latest/administration/provisioning/#dashboards) for more information.
 
+### node-exporter
+
+Deploys [node-exporter](https://github.com/prometheus/node_exporter) in the `monitoring` namespace onto any node labeled with `role.scaffolding/monitored=true`.
+A ServiceMonitor is created to allow for collection from Prometheus.
+A dashboard for the exported metrics is included within the grafana kustomization (see above).
+
+`HostNetwork` is enabled to allow for network metrics on the node to be collected.
+
 ### monitoring-ns
 
 Creates a namespace named 'monitoring'.


### PR DESCRIPTION
This one slipped through while updating the README previously in https://github.com/cilium/scaffolding/commit/ed6b80d69c3509c5b0a6dd712a6b2111bfe07366.

Note: cadvisor also slipped through, but I purposefully didn't add it into the README as it will eventually be removed due to https://github.com/cilium/scaffolding/issues/65.

Signed-off-by: Ryan Drew <ryan.drew@isovalent.com>