### PR TITLE
Various Maintenance Fixes

### DIFF
--- a/kustomize/topologies/pod2pod/base/client.yaml
+++ b/kustomize/topologies/pod2pod/base/client.yaml
@@ -17,3 +17,4 @@ spec:
       containers:
       - name: main
         image: k8s.gcr.io/pause:3.1
+        command: ["sleep", "infinity"]

--- a/kustomize/topologies/pod2pod/base/deployment.yaml
+++ b/kustomize/topologies/pod2pod/base/deployment.yaml
@@ -1,4 +1,4 @@
-  apiVersion: apps/v1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pod2pod

--- a/scenarios/xdp/kustomization.yaml
+++ b/scenarios/xdp/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+- ../../kustomize/monitoring-ns
 - ../../kustomize/prometheus
 - ../../kustomize/node-exporter
 - ../../kustomize/grafana

--- a/scripts/get_ciliumcli.sh
+++ b/scripts/get_ciliumcli.sh
@@ -7,9 +7,11 @@
 # cwd rather than /usr/local/bin
 set -eo pipefail
 
+VERBOSE=""
 if [ "${1}" == '-d' ]
 then
     set -x
+    VERBOSE="--verbose"
     shift 1
 fi
 
@@ -17,7 +19,7 @@ CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli
 GOOS=$(go env GOOS)
 GOARCH=$(go env GOARCH)
 
-curl -L --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-${GOOS}-${GOARCH}.tar.gz{,.sha256sum}
+curl $VERBOSE -L --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-${GOOS}-${GOARCH}.tar.gz{,.sha256sum}
 sha256sum --check cilium-${GOOS}-${GOARCH}.tar.gz.sha256sum
 tar -xzvf cilium-${GOOS}-${GOARCH}.tar.gz
 

--- a/scripts/get_crane.sh
+++ b/scripts/get_crane.sh
@@ -5,9 +5,11 @@
 # Download crane binary from github.com/google/go-containerregistry
 set -eo pipefail
 
+VERBOSE=""
 if [ "${1}" == '-d' ]
 then
     set -x
+    VERBOSE="--verbose"
     shift 1
 fi
 
@@ -28,7 +30,7 @@ fi
 
 TARBALL="go-containerregistry_${GOOS}_${GOARCH}.tar.gz"
 
-curl -L --remote-name-all https://github.com/google/go-containerregistry/releases/download/${CRANE_VERSION}/{${TARBALL},checksums.txt}
+curl $VERBOSE -L --remote-name-all https://github.com/google/go-containerregistry/releases/download/${CRANE_VERSION}/{${TARBALL},checksums.txt}
 sha256sum --ignore-missing -c checksums.txt
 tar -xzvf $TARBALL crane
 


### PR DESCRIPTION
This PR introduces a collection of commits that are too small for their own PRs but are important none-the-less. See each commit for details on what's included, but here's a high level summary:

* Add `--verbose` option to curl in `get_ciliumcli.sh` and `get_crane.sh` when `-d` is given.
* Have the client pod in `kustomize/topologies/pod2pod` run a `sleep infinity` by default. It's pretty common for the client pod to just sleep forever and be exec'd into through `kubectl` to kick off a test.
* Remove a couple of spaces that somehow got added to the beginning of `kustomize/toplogies/pod2pod/base/deployment.yaml`.
* Add `kustomize/monitoring-ns` to xdp's kustomization. Required for the monitoring resources to be deployed in `xdp.sh` without first manually creating the `monitoring` namespace.