### PR TITLE
k8s/helper: Modify ApplyResource to return result from k8s API

### DIFF
--- a/toolkit/cmd/ron.go
+++ b/toolkit/cmd/ron.go
@@ -113,9 +113,17 @@ var ronCmd = &cobra.Command{
 	Use:   "ron",
 	Short: "Run On Node",
 	Run: func(_ *cobra.Command, args []string) {
-		exitIfError := func(err error) {
-			if err != nil {
-				toolkit.ExitWithError(Logger, err)
+		exitIfError := func(args ...any) {
+			if len(args) == 0 {
+				return
+			}
+			lastArg := args[len(args)-1]
+			if lastArg != nil {
+				err, ok := lastArg.(error)
+				if !ok {
+					return
+				}
+				toolkit.ExitWithError(Logger, err.(error))
 			}
 		}
 


### PR DESCRIPTION
This commit modifies `Helper.ApplyResource` to return the result received from the k8s API after applying the user's input. This allows the user to inspect the applied resource without having to perform a follow-up get on it.