### PR TITLE
toolkit/helper: Change WaitOnWatchedResource to use client-go tools

### DIFF
--- a/toolkit/toolkit/k8s/unstructured.go
+++ b/toolkit/toolkit/k8s/unstructured.go
@@ -44,6 +44,16 @@ var (
 		Resource: "ciliumnetworkpolicies",
 		Version:  "v2",
 	}
+	ResourceToKind = map[string]string{
+		GVRPod.Resource:                   "Pod",
+		GVRNode.Resource:                  "Node",
+		GVRDeployment.Resource:            "Deployment",
+		GVRNamespace.Resource:             "Namespace",
+		GVRPersistentVolumeClaim.Resource: "PersistentVolumeClaim",
+		GVRConfigMap.Resource:             "ConfigMap",
+		GVREvents.Resource:                "Event",
+		GVRCiliumNetworkPolicy.Resource:   "CiliumNetworkPolicy",
+	}
 	ScaffoldingLabel         = "cilium.scaffolding"
 	ScaffoldingLabelSelector = fmt.Sprintf("app.kubernetes.io=%s", ScaffoldingLabel)
 )

--- a/toolkit/toolkit/k8s/util.go
+++ b/toolkit/toolkit/k8s/util.go
@@ -2,14 +2,10 @@ package k8s
 
 import (
 	"fmt"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// NewListOptionsFromName constructs a new ListOptions that uses a FieldSelector
+// NewFieldSelectorFromName constructs a new field selector
 // to target resources whose metadata.name attribute matches the given name.
-func NewListOptionsFromName(name string) metav1.ListOptions {
-	return metav1.ListOptions{
-		FieldSelector: fmt.Sprintf("metadata.name=%s", name),
-	}
+func NewFieldSelectorFromName(name string) string {
+	return fmt.Sprintf("metadata.name=%s", name)
 }


### PR DESCRIPTION
This commit modifies the implementation of helper.WaitOnWatchedResource by replacing its guts with tools from client-go/tools/watch and client-go/tools/cache, namely watch.UntilWithSync. Before this commit, the implementation of helper.WaitOnWatchedResource tried to accomplish the same task, but lacked the error handling capabilities that the client-go package provides already.