### PR TITLE
Improve Helper Usability and Error Handling

### DIFF
--- a/toolkit/cmd/verify_k8s_ready.go
+++ b/toolkit/cmd/verify_k8s_ready.go
@@ -19,9 +19,9 @@ var verifyK8sReadyCmd = &cobra.Command{
 	Use:   "k8s-ready",
 	Short: "verify k8s cluster is ready to go",
 	Run: func(_ *cobra.Command, _ []string) {
-		khelp := k8s.NewHelperOrDie(CmdCtx, Logger, Kubeconfig)
+		khelp := k8s.NewHelperOrDie(Logger, Kubeconfig)
 
-		nodesReady, err := khelp.VerifyResourcesAreReady(*k8s.GVRNode)
+		nodesReady, err := khelp.VerifyResourcesAreReady(CmdCtx, *k8s.GVRNode)
 		if err != nil {
 			toolkit.ExitWithError(Logger, err)
 		}
@@ -29,7 +29,7 @@ var verifyK8sReadyCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		podsReady, err := khelp.VerifyResourcesAreReady(*k8s.GVRPod)
+		podsReady, err := khelp.VerifyResourcesAreReady(CmdCtx, *k8s.GVRPod)
 		if err != nil {
 			toolkit.ExitWithError(Logger, err)
 		}
@@ -38,7 +38,7 @@ var verifyK8sReadyCmd = &cobra.Command{
 		}
 
 		deploymentsReady, err := khelp.VerifyResourcesAreReady(
-			*k8s.GVRDeployment,
+			CmdCtx, *k8s.GVRDeployment,
 		)
 		if err != nil {
 			toolkit.ExitWithError(Logger, err)

--- a/toolkit/toolkit/k8s/unstructured.go
+++ b/toolkit/toolkit/k8s/unstructured.go
@@ -44,6 +44,16 @@ var (
 		Resource: "ciliumnetworkpolicies",
 		Version:  "v2",
 	}
+	ResourceToKind = map[string]string{
+		GVRPod.Resource:                   "Pod",
+		GVRNode.Resource:                  "Node",
+		GVRDeployment.Resource:            "Deployment",
+		GVRNamespace.Resource:             "Namespace",
+		GVRPersistentVolumeClaim.Resource: "PersistentVolumeClaim",
+		GVRConfigMap.Resource:             "ConfigMap",
+		GVREvents.Resource:                "Event",
+		GVRCiliumNetworkPolicy.Resource:   "CiliumNetworkPolicy",
+	}
 	ScaffoldingLabel         = "cilium.scaffolding"
 	ScaffoldingLabelSelector = fmt.Sprintf("app.kubernetes.io=%s", ScaffoldingLabel)
 )

--- a/toolkit/toolkit/k8s/util.go
+++ b/toolkit/toolkit/k8s/util.go
@@ -2,14 +2,10 @@ package k8s
 
 import (
 	"fmt"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// NewListOptionsFromName constructs a new ListOptions that uses a FieldSelector
+// NewFieldSelectorFromName constructs a new field selector
 // to target resources whose metadata.name attribute matches the given name.
-func NewListOptionsFromName(name string) metav1.ListOptions {
-	return metav1.ListOptions{
-		FieldSelector: fmt.Sprintf("metadata.name=%s", name),
-	}
+func NewFieldSelectorFromName(name string) string {
+	return fmt.Sprintf("metadata.name=%s", name)
 }


### PR DESCRIPTION
Two changes in this PR:

* Modify the Helper's WaitOnWatchedResource to use k8s client-go's watch tools. This function essentially did the same thing as client-go's [watch.Until](https://pkg.go.dev/k8s.io/client-go@v0.26.3/tools/watch#Until) function, so I gutted WaitOnWatchResource to use [watch.UntilWithSync](https://pkg.go.dev/k8s.io/client-go@v0.26.3/tools/watch#UntilWithSync), which has great error handling. This way we don't have to maintain a tool that already exists.
* Removed Ctx from the Helper, so users can pass their own context into each function as needed.

These are breaking changes.