### PR TITLE
toolkit/helper: Fix race condition in DeleteResourceAndWaitGone

### DIFF
--- a/toolkit/cmd/ron.go
+++ b/toolkit/cmd/ron.go
@@ -311,8 +311,7 @@ var ronCmd = &cobra.Command{
 
 			// this becomes our main loop, waiting for pod to start and complete
 			_, err = khelp.WaitOnWatchedResource(
-				CmdCtx, *k8s.GVRPod, RonOpts.NSName,
-				k8s.NewFieldSelectorFromName(RonOpts.PodName), "", handleEventOnRonPod,
+				CmdCtx, *k8s.GVRPod, RonOpts.NSName, k8s.NewFieldSelectorFromName(RonOpts.PodName), "", nil, handleEventOnRonPod,
 			)
 			exitIfError(err)
 


### PR DESCRIPTION
In the method, Helper.DeleteResourceAndWaitGone, a race condition can occur if the given resource is deleted before the watch on the resource is started. If this happens, DeleteResourceAndWaitGone will hang forever because it will never observe a deletion event on the resource. To address this, four changes were made:

1. Modify WaitOnWatchResource to wait for a cache sync by adding a precondition (see https://github.com/kubernetes/client-go/blob/04ef61f72b7bc5ae6efef4e4dc0001746637fdb3/tools/watch/until.go#L137). The precondition will call a given callback to signal that the cache sync has occurred.
2. Modify DeleteResourceAndWaitGone to wait to delete the given resource until the cache sync has occurred.
3. Modify DeleteResourceAndWaitGone to perform an initial check using a 'Get' call to see if the given resource even exists before watching for a deletion event. This will cover the case in which DeleteResourceAndWaitGone is called on a resourcce that doesn't exist at the time the function was called.
4. Modify DeleteResourceAndWaitGone to check if the error returned by 'Delete' is a 'resource not found' error, to handle the case where the resource is deleted by something else in-between checking if the resource exists and waiting for the deletion event.

Fixes: #76