### PR TITLE
Add network-performance tests to dashboard.

### DIFF
--- a/scale-tests/jobs/network-performance.yaml
+++ b/scale-tests/jobs/network-performance.yaml
@@ -1,0 +1,33 @@
+periodics:
+- name: gke-perf-native-hubble-main
+  tags:
+  - "perfDashPrefix: gke-perf-native-hubble-main"
+  - "perfDashJobType: networking"
+- name: gke-perf-native-ipsec-hubble-main
+  tags:
+  - "perfDashPrefix: gke-perf-native-ipsec-hubble-main"
+  - "perfDashJobType: networking"
+- name: gke-perf-native-ipsec-main
+  tags:
+  - "perfDashPrefix: gke-perf-native-ipsec-main"
+  - "perfDashJobType: networking"
+- name: gke-perf-native-main
+  tags:
+  - "perfDashPrefix: gke-perf-native-main"
+  - "perfDashJobType: networking"
+- name: gke-perf-tunnel-hubble-main
+  tags:
+  - "perfDashPrefix: gke-perf-tunnel-hubble-main"
+  - "perfDashJobType: networking"
+- name: gke-perf-tunnel-ipsec-hubble-main
+  tags:
+  - "perfDashPrefix: gke-perf-tunnel-ipsec-hubble-main"
+  - "perfDashJobType: networking"
+- name: gke-perf-tunnel-ipsec-main
+  tags:
+  - "perfDashPrefix: gke-perf-tunnel-ipsec-main"
+  - "perfDashJobType: networking"
+- name: gke-perf-tunnel-main
+  tags:
+  - "perfDashPrefix: gke-perf-tunnel-main"
+  - "perfDashJobType: networking"


### PR DESCRIPTION
Support was added in upstream PR: https://github.com/kubernetes/perf-tests/pull/2648