### PR TITLE
Make cmapisrv-mock tolerations and nodeSelector configurable

### DIFF
--- a/cmapisrv-mock/deploy/cmapisrv-mock/templates/deployment.yaml
+++ b/cmapisrv-mock/deploy/cmapisrv-mock/templates/deployment.yaml
@@ -164,3 +164,12 @@ spec:
       - name: etcd-data-dir
         emptyDir:
           medium: Memory
+
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/cmapisrv-mock/deploy/cmapisrv-mock/values.yaml
+++ b/cmapisrv-mock/deploy/cmapisrv-mock/values.yaml
@@ -46,6 +46,9 @@ config:
 podAnnotations: {}
 podLabels: {}
 
+nodeSelector: {}
+tolerations: []
+
 service:
   type: ClusterIP
   port: 2379


### PR DESCRIPTION
This allows, for instance, to force scheduling the mocker on control plane nodes, to ensure consistency during testing when using different instance types.