### PR TITLE
Make cmapisrv-mock addresses configurable

### DIFF
--- a/cmapisrv-mock/deploy/cmapisrv-mock/templates/deployment.yaml
+++ b/cmapisrv-mock/deploy/cmapisrv-mock/templates/deployment.yaml
@@ -107,6 +107,12 @@ spec:
         - --endpoints-qps={{ .Values.config.endpointsQPS }}
         - --services={{ .Values.config.services }}
         - --services-qps={{ .Values.config.servicesQPS }}
+        - --random-node-ip4={{ .Values.config.randomNodeIP4 }}
+        - --random-node-ip6={{ .Values.config.randomNodeIP6 }}
+        - --random-pod-ip4={{ .Values.config.randomPodIP4 }}
+        - --random-pod-ip6={{ .Values.config.randomPodIP6 }}
+        - --random-svc-ip4={{ .Values.config.randomSvcIP4 }}
+        - --random-svc-ip6={{ .Values.config.randomSvcIP6 }}
         - --kvstore-opt=etcd.config=/var/lib/cilium/etcd-config.yaml
         - --kvstore-opt=etcd.qps={{ .Values.config.etcdQPS }}
         - --kvstore-opt=etcd.maxInflight={{ .Values.config.etcdMaxInflight }}

--- a/cmapisrv-mock/deploy/cmapisrv-mock/values.yaml
+++ b/cmapisrv-mock/deploy/cmapisrv-mock/values.yaml
@@ -39,6 +39,21 @@ config:
   # Number of service create/update/delete operations per second at run-time.
   servicesQPS: 5
 
+  # The first mocked node IPv4 address
+  randomNodeIP4: 172.16.0.0
+  # The first mocked node IPv6 address
+  randomNodeIP6: fc00::0
+
+  # The first mocked pod IPv4 address
+  randomPodIP4: 10.0.0.0
+  # The first mocked pod IPv6 address
+  randomPodIP6: fd00::0
+
+  # The first mocked service IPv4 address
+  randomSvcIP4: 172.252.0.0
+  # The first mocked service IPv6 address
+  randomSvcIP6: fdff::0
+
   # Global etcd rate limiting settings.
   etcdQPS: 1000
   etcdMaxInflight: 100

--- a/cmapisrv-mock/internal/mocker/cache.go
+++ b/cmapisrv-mock/internal/mocker/cache.go
@@ -18,7 +18,7 @@ func newCache[T store.Key]() cache[T] {
 	return cache[T]{keys: make(map[string]int)}
 }
 
-func (c *cache[T]) Get() T {
+func (c *cache[T]) Get(rnd *random) T {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
@@ -41,7 +41,7 @@ func (c *cache[T]) Upsert(value T) {
 	c.upsert(value, true)
 }
 
-func (c *cache[T]) Remove() T {
+func (c *cache[T]) Remove(rnd *random) T {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 

--- a/cmapisrv-mock/internal/mocker/cells.go
+++ b/cmapisrv-mock/internal/mocker/cells.go
@@ -23,6 +23,7 @@ var Cell = cell.Module(
 	"Cilium Cluster Mesh Mocker",
 
 	cell.Config(defaultConfig),
+	cell.Config(defaultRndcfg),
 
 	controller.Cell,
 	job.Cell,

--- a/cmapisrv-mock/internal/mocker/cells.go
+++ b/cmapisrv-mock/internal/mocker/cells.go
@@ -40,6 +40,7 @@ var Cell = cell.Module(
 	gops.Cell(defaults.GopsPortKVStoreMesh),
 	cmmetrics.Cell,
 
+	cell.Provide(newRandom),
 	cell.Provide(newMocker),
 	cell.Invoke(func(_ *mocker) {}),
 )

--- a/cmapisrv-mock/internal/mocker/cluster.go
+++ b/cmapisrv-mock/internal/mocker/cluster.go
@@ -24,7 +24,7 @@ type clusters struct {
 	cls []cluster
 }
 
-func newClusters(log logrus.FieldLogger, cfg config, factory store.Factory, backend kvstore.BackendOperations) clusters {
+func newClusters(log logrus.FieldLogger, cfg config, factory store.Factory, backend kvstore.BackendOperations, rnd *random) clusters {
 	cls := clusters{cfg: cfg}
 
 	for i := uint(0); i < cfg.Clusters; i++ {
@@ -36,6 +36,7 @@ func newClusters(log logrus.FieldLogger, cfg config, factory store.Factory, back
 				cluster:    cmtypes.ClusterInfo{ID: uint32(id), Name: name},
 				factory:    factory,
 				backend:    backend,
+				rnd:        rnd,
 				enableIPv6: cfg.EnableIPv6,
 			}))
 	}
@@ -74,6 +75,7 @@ type cparams struct {
 	cluster    cmtypes.ClusterInfo
 	factory    store.Factory
 	backend    kvstore.BackendOperations
+	rnd        *random
 	enableIPv6 bool
 }
 

--- a/cmapisrv-mock/internal/mocker/config.go
+++ b/cmapisrv-mock/internal/mocker/config.go
@@ -54,3 +54,32 @@ func (def config) Flags(flags *pflag.FlagSet) {
 	flags.Uint("services", def.Endpoints, "Number of services to mock (per cluster)")
 	flags.Float64("services-qps", def.EndpointsQPS, "Services QPS (per cluster)")
 }
+
+type rndcfg struct {
+	RandomNodeIP4 string
+	RandomNodeIP6 string
+	RandomPodIP4  string
+	RandomPodIP6  string
+	RandomSvcIP4  string
+	RandomSvcIP6  string
+}
+
+var defaultRndcfg = rndcfg{
+	RandomNodeIP4: "172.16.0.0",
+	RandomNodeIP6: "fc00::0",
+	RandomPodIP4:  "10.0.0.0",
+	RandomPodIP6:  "fd00::0",
+	RandomSvcIP4:  "172.252.0.0",
+	RandomSvcIP6:  "fdff::0",
+}
+
+func (def rndcfg) Flags(flags *pflag.FlagSet) {
+	flags.String("random-node-ip4", def.RandomNodeIP4, "The first mocked node IPv4 address")
+	flags.String("random-node-ip6", def.RandomNodeIP6, "The first mocked node IPv6 address")
+
+	flags.String("random-pod-ip4", def.RandomPodIP4, "The first mocked pod IPv4 address")
+	flags.String("random-pod-ip6", def.RandomPodIP6, "The first mocked pod IPv6 address")
+
+	flags.String("random-svc-ip4", def.RandomSvcIP4, "The first mocked service IPv4 address")
+	flags.String("random-svc-ip6", def.RandomSvcIP6, "The first mocked service IPv6 address")
+}

--- a/cmapisrv-mock/internal/mocker/endpoint.go
+++ b/cmapisrv-mock/internal/mocker/endpoint.go
@@ -30,24 +30,23 @@ type endpoints struct {
 }
 
 func newEndpoints(
-	log logrus.FieldLogger, cluster cmtypes.ClusterInfo,
-	factory store.Factory, backend store.SyncStoreBackend,
-	enableIPv6 bool, nodes *nodes, identities *identities) *endpoints {
+	log logrus.FieldLogger, cp cparams,
+	nodes *nodes, identities *identities) *endpoints {
 
 	prefix := kvstore.StateToCachePrefix(IPIdentitiesPath)
-	ss := factory.NewSyncStore(cluster.Name, backend,
-		path.Join(prefix, cluster.Name),
+	ss := cp.factory.NewSyncStore(cp.cluster.Name, cp.backend,
+		path.Join(prefix, cp.cluster.Name),
 		store.WSSWithSyncedKeyOverride(prefix))
 
 	eps := &endpoints{
-		cluster:        cluster,
+		cluster:        cp.cluster,
 		cache:          newCache[*identity.IPIdentityPair](),
 		podIPGetter:    rnd.PodIP4,
 		nodeIPGetter:   nodes.RandomHostIP,
 		identityGetter: identities.RandomIdentity,
 	}
 
-	if enableIPv6 {
+	if cp.enableIPv6 {
 		eps.podIPGetter = rnd.PodIP
 	}
 

--- a/cmapisrv-mock/internal/mocker/endpoint.go
+++ b/cmapisrv-mock/internal/mocker/endpoint.go
@@ -48,7 +48,7 @@ func newEndpoints(
 	}
 
 	if enableIPv6 {
-		eps.podIPGetter = rnd.PodIP6
+		eps.podIPGetter = rnd.PodIP
 	}
 
 	eps.syncer = newSyncer(log, "ips", ss, eps.next)

--- a/cmapisrv-mock/internal/mocker/identity.go
+++ b/cmapisrv-mock/internal/mocker/identity.go
@@ -26,16 +26,16 @@ type identities struct {
 	encoder func([]byte) string
 }
 
-func newIdentities(log logrus.FieldLogger, cluster cmtypes.ClusterInfo, factory store.Factory, backend kvstore.BackendOperations) *identities {
+func newIdentities(log logrus.FieldLogger, cp cparams) *identities {
 	prefix := kvstore.StateToCachePrefix(IdentitiesPath)
-	ss := factory.NewSyncStore(cluster.Name, backend,
-		path.Join(prefix, cluster.Name, "id"),
+	ss := cp.factory.NewSyncStore(cp.cluster.Name, cp.backend,
+		path.Join(prefix, cp.cluster.Name, "id"),
 		store.WSSWithSyncedKeyOverride(prefix))
 
 	ids := &identities{
-		cluster: cluster,
+		cluster: cp.cluster,
 		cache:   newCache[*store.KVPair](),
-		encoder: backend.Encode,
+		encoder: cp.backend.Encode,
 	}
 
 	ids.syncer = newSyncer(log, "identities", ss, ids.next)

--- a/cmapisrv-mock/internal/mocker/mocker.go
+++ b/cmapisrv-mock/internal/mocker/mocker.go
@@ -25,6 +25,7 @@ type mocker struct {
 
 	backend promise.Promise[kvstore.BackendOperations]
 	factory store.Factory
+	rnd     *random
 
 	syncState syncstate.SyncState
 }
@@ -40,6 +41,7 @@ func newMocker(in struct {
 	Config    config
 	Backend   promise.Promise[kvstore.BackendOperations]
 	Factory   store.Factory
+	Random    *random
 	SyncState syncstate.SyncState
 }) *mocker {
 	mk := &mocker{
@@ -47,6 +49,7 @@ func newMocker(in struct {
 		log:       in.Logger,
 		backend:   in.Backend,
 		factory:   in.Factory,
+		rnd:       in.Random,
 		syncState: in.SyncState,
 	}
 
@@ -67,7 +70,7 @@ func (mk *mocker) Run(ctx context.Context, _ cell.HealthReporter) error {
 		return err
 	}
 
-	cls := newClusters(mk.log, mk.cfg, mk.factory, backend)
+	cls := newClusters(mk.log, mk.cfg, mk.factory, backend, mk.rnd)
 	cls.Run(ctx, mk.syncState)
 	return nil
 }

--- a/cmapisrv-mock/internal/mocker/node.go
+++ b/cmapisrv-mock/internal/mocker/node.go
@@ -27,16 +27,16 @@ type nodes struct {
 	enableIPv6 bool
 }
 
-func newNodes(log logrus.FieldLogger, cluster cmtypes.ClusterInfo, factory store.Factory, backend store.SyncStoreBackend, enableIPv6 bool) *nodes {
+func newNodes(log logrus.FieldLogger, cp cparams) *nodes {
 	prefix := kvstore.StateToCachePrefix(nodeStore.NodeStorePrefix)
-	ss := factory.NewSyncStore(cluster.Name, backend,
-		path.Join(prefix, cluster.Name),
+	ss := cp.factory.NewSyncStore(cp.cluster.Name, cp.backend,
+		path.Join(prefix, cp.cluster.Name),
 		store.WSSWithSyncedKeyOverride(prefix))
 
 	ns := &nodes{
-		cluster:    cluster,
+		cluster:    cp.cluster,
 		cache:      newCache[*nodeTypes.Node](),
-		enableIPv6: enableIPv6,
+		enableIPv6: cp.enableIPv6,
 	}
 
 	ns.syncer = newSyncer(log, "nodes", ss, ns.next)

--- a/cmapisrv-mock/internal/mocker/random.go
+++ b/cmapisrv-mock/internal/mocker/random.go
@@ -22,17 +22,23 @@ type random struct {
 	cidr4, cidr6     prefix
 }
 
-func newRandom() *random {
+func newRandom(cfg rndcfg) (rnd *random, err error) {
+	defer func() {
+		if got := recover(); got != nil {
+			err = got.(error)
+		}
+	}()
+
 	return &random{
-		nodeIP4: addr{addr: netip.MustParseAddr("172.16.0.0")},
-		nodeIP6: addr{addr: netip.MustParseAddr("fc00::0")},
-		podIP4:  addr{addr: netip.MustParseAddr("10.0.0.0")},
-		podIP6:  addr{addr: netip.MustParseAddr("fd00::0")},
-		svcIP4:  addr{addr: netip.MustParseAddr("172.252.0.0")},
-		svcIP6:  addr{addr: netip.MustParseAddr("fdff::0")},
-		cidr4:   prefix{pfx: netip.MustParsePrefix("10.0.0.0/28")},
-		cidr6:   prefix{pfx: netip.MustParsePrefix("fd00::0/120")},
-	}
+		nodeIP4: addr{addr: netip.MustParseAddr(cfg.RandomNodeIP4)},
+		nodeIP6: addr{addr: netip.MustParseAddr(cfg.RandomNodeIP6)},
+		podIP4:  addr{addr: netip.MustParseAddr(cfg.RandomPodIP4)},
+		podIP6:  addr{addr: netip.MustParseAddr(cfg.RandomPodIP6)},
+		svcIP4:  addr{addr: netip.MustParseAddr(cfg.RandomSvcIP4)},
+		svcIP6:  addr{addr: netip.MustParseAddr(cfg.RandomSvcIP6)},
+		cidr4:   prefix{pfx: netip.MustParsePrefix(cfg.RandomPodIP4 + "/28")},
+		cidr6:   prefix{pfx: netip.MustParsePrefix(cfg.RandomPodIP6 + "/120")},
+	}, nil
 }
 
 func (r *random) Name() string      { return petname.Generate(2, "-") }

--- a/cmapisrv-mock/internal/mocker/random.go
+++ b/cmapisrv-mock/internal/mocker/random.go
@@ -22,15 +22,17 @@ type random struct {
 	cidr4, cidr6     prefix
 }
 
-var rnd = random{
-	nodeIP4: addr{addr: netip.MustParseAddr("172.16.0.0")},
-	nodeIP6: addr{addr: netip.MustParseAddr("fc00::0")},
-	podIP4:  addr{addr: netip.MustParseAddr("10.0.0.0")},
-	podIP6:  addr{addr: netip.MustParseAddr("fd00::0")},
-	svcIP4:  addr{addr: netip.MustParseAddr("172.252.0.0")},
-	svcIP6:  addr{addr: netip.MustParseAddr("fdff::0")},
-	cidr4:   prefix{pfx: netip.MustParsePrefix("10.0.0.0/28")},
-	cidr6:   prefix{pfx: netip.MustParsePrefix("fd00::0/120")},
+func newRandom() *random {
+	return &random{
+		nodeIP4: addr{addr: netip.MustParseAddr("172.16.0.0")},
+		nodeIP6: addr{addr: netip.MustParseAddr("fc00::0")},
+		podIP4:  addr{addr: netip.MustParseAddr("10.0.0.0")},
+		podIP6:  addr{addr: netip.MustParseAddr("fd00::0")},
+		svcIP4:  addr{addr: netip.MustParseAddr("172.252.0.0")},
+		svcIP6:  addr{addr: netip.MustParseAddr("fdff::0")},
+		cidr4:   prefix{pfx: netip.MustParsePrefix("10.0.0.0/28")},
+		cidr6:   prefix{pfx: netip.MustParsePrefix("fd00::0/120")},
+	}
 }
 
 func (r *random) Name() string      { return petname.Generate(2, "-") }
@@ -69,7 +71,7 @@ func (r *random) IdentityLabels(cluster string) labels.LabelArray {
 	n := rand.Intn(8) + 1
 	lbls := make(labels.LabelArray, 0, n+4)
 
-	ns := rnd.Namespace()
+	ns := r.Namespace()
 	lbls = append(lbls, labels.NewLabel("io.kubernetes.pod.namespace", ns, labels.LabelSourceK8s))
 	lbls = append(lbls, labels.NewLabel("io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name", ns, labels.LabelSourceK8s))
 	lbls = append(lbls, labels.NewLabel("io.cilium.k8s.policy.serviceaccount", petname.Name(), labels.LabelSourceK8s))

--- a/cmapisrv-mock/internal/mocker/service.go
+++ b/cmapisrv-mock/internal/mocker/service.go
@@ -24,17 +24,16 @@ type services struct {
 	enableIPv6 bool
 }
 
-func newServices(log logrus.FieldLogger, cluster cmtypes.ClusterInfo,
-	factory store.Factory, backend store.SyncStoreBackend, enableIPv6 bool) *services {
+func newServices(log logrus.FieldLogger, cp cparams) *services {
 	prefix := kvstore.StateToCachePrefix(serviceStore.ServiceStorePrefix)
-	ss := factory.NewSyncStore(cluster.Name, backend,
-		path.Join(prefix, cluster.Name),
+	ss := cp.factory.NewSyncStore(cp.cluster.Name, cp.backend,
+		path.Join(prefix, cp.cluster.Name),
 		store.WSSWithSyncedKeyOverride(prefix))
 
 	svc := &services{
-		cluster:    cluster,
+		cluster:    cp.cluster,
 		cache:      newCache[*serviceStore.ClusterService](),
-		enableIPv6: enableIPv6,
+		enableIPv6: cp.enableIPv6,
 	}
 
 	svc.syncer = newSyncer(log, "services", ss, svc.next)


### PR DESCRIPTION
To allow configuring different ranges in case they overlap with other infrastructural addresses, and prevent breaking connectivity. Additionally, let's fix the endpoint mocking logic that incorrectly always picked IPv6 addresses when IPv6 was enabled.