### PR TITLE
Speed up cmapisrv-mock startup phase 

### DIFF
--- a/cmapisrv-mock/deploy/cmapisrv-mock/templates/deployment.yaml
+++ b/cmapisrv-mock/deploy/cmapisrv-mock/templates/deployment.yaml
@@ -115,6 +115,7 @@ spec:
         - --random-svc-ip6={{ .Values.config.randomSvcIP6 }}
         - --kvstore-opt=etcd.config=/var/lib/cilium/etcd-config.yaml
         - --kvstore-opt=etcd.qps={{ .Values.config.etcdQPS }}
+        - --kvstore-opt=etcd.bootstrapQps={{ .Values.config.etcdBootstrapQPS }}
         - --kvstore-opt=etcd.maxInflight={{ .Values.config.etcdMaxInflight }}
         - --prometheus-serve-addr=:9999
         ports:

--- a/cmapisrv-mock/deploy/cmapisrv-mock/values.yaml
+++ b/cmapisrv-mock/deploy/cmapisrv-mock/values.yaml
@@ -56,6 +56,7 @@ config:
 
   # Global etcd rate limiting settings.
   etcdQPS: 1000
+  etcdBootstrapQPS: 10000
   etcdMaxInflight: 100
 
 podAnnotations: {}

--- a/cmapisrv-mock/internal/mocker/cells.go
+++ b/cmapisrv-mock/internal/mocker/cells.go
@@ -30,7 +30,11 @@ var Cell = cell.Module(
 
 	kvstore.Cell(kvstore.EtcdBackendName),
 	heartbeat.Cell,
-	cell.Provide(func() *kvstore.ExtraOptions { return nil }),
+	cell.Provide(func(ss syncstate.SyncState) *kvstore.ExtraOptions {
+		return &kvstore.ExtraOptions{
+			BootstrapComplete: ss.WaitChannel(),
+		}
+	}),
 	store.Cell,
 
 	cmhealth.HealthAPIServerCell,

--- a/cmapisrv-mock/internal/mocker/syncer.go
+++ b/cmapisrv-mock/internal/mocker/syncer.go
@@ -35,14 +35,14 @@ func (s syncer[T]) Run(ctx context.Context, target uint, qps rate.Limit) {
 	s.log.Info("Starting synchronization")
 	do := func(obj T, delete bool) {
 		if delete {
-			s.log.WithField("key", obj.GetKeyName()).Info("Deleting key")
+			s.log.WithField("key", obj.GetKeyName()).Debug("Deleting key")
 			if err := s.store.DeleteKey(ctx, obj); err != nil {
 				s.log.WithError(err).Fatal("Failed to delete key")
 			}
 			return
 		}
 
-		s.log.WithField("key", obj.GetKeyName()).Info("Upserting key")
+		s.log.WithField("key", obj.GetKeyName()).Debug("Upserting key")
 		if err := s.store.UpsertKey(ctx, obj); err != nil {
 			s.log.WithError(err).Fatal("Failed to upsert key")
 		}


### PR DESCRIPTION
* Lower verbosity level of per-key logs;
* Wait for full synchronization before starting churn phase;
* Configure bootstrap QPS to speed-up initial synchronization.