### PR TITLE
Fix incorrect nodes and services path generated by cmapisrv-mock

### DIFF
--- a/cmapisrv-mock/internal/mocker/node.go
+++ b/cmapisrv-mock/internal/mocker/node.go
@@ -5,7 +5,6 @@ package mocker
 
 import (
 	"net"
-	"path"
 
 	"github.com/sirupsen/logrus"
 
@@ -13,7 +12,6 @@ import (
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/kvstore"
-	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/node/addressing"
 	nodeStore "github.com/cilium/cilium/pkg/node/store"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
@@ -30,9 +28,7 @@ type nodes struct {
 
 func newNodes(log logrus.FieldLogger, cp cparams) *nodes {
 	prefix := kvstore.StateToCachePrefix(nodeStore.NodeStorePrefix)
-	ss := cp.factory.NewSyncStore(cp.cluster.Name, cp.backend,
-		path.Join(prefix, cp.cluster.Name),
-		store.WSSWithSyncedKeyOverride(prefix))
+	ss := cp.factory.NewSyncStore(cp.cluster.Name, cp.backend, prefix)
 
 	ns := &nodes{
 		cluster:    cp.cluster,

--- a/cmapisrv-mock/internal/mocker/service.go
+++ b/cmapisrv-mock/internal/mocker/service.go
@@ -4,14 +4,11 @@
 package mocker
 
 import (
-	"path"
-
 	"github.com/sirupsen/logrus"
 	"golang.org/x/exp/maps"
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/kvstore"
-	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	serviceStore "github.com/cilium/cilium/pkg/service/store"
 )
@@ -27,9 +24,7 @@ type services struct {
 
 func newServices(log logrus.FieldLogger, cp cparams) *services {
 	prefix := kvstore.StateToCachePrefix(serviceStore.ServiceStorePrefix)
-	ss := cp.factory.NewSyncStore(cp.cluster.Name, cp.backend,
-		path.Join(prefix, cp.cluster.Name),
-		store.WSSWithSyncedKeyOverride(prefix))
+	ss := cp.factory.NewSyncStore(cp.cluster.Name, cp.backend, prefix)
 
 	svc := &services{
 		cluster:    cp.cluster,


### PR DESCRIPTION
Currently, the mocked nodes and services prefixes incorrectly contain the cluster name twice, as both explicitly configured as part of the sync store prefix and automatically added as part of the key generation. This mistake got previously unnoticed, as the base prefix was correct and, historically, Cilium did not use the key during unmarshalling. However, the introduction of more thorough validation brought this issue to light, and is now being fixed.