### PR TITLE
egw: Another round of bugfixes

### DIFF
--- a/egw-scale-utils/test/config.yaml
+++ b/egw-scale-utils/test/config.yaml
@@ -5,6 +5,7 @@
 name: egw-scale-test-masq-delay
 namespace:
   number: 1
+  deleteAutomanagedNamespaces: false
 tuningSets:
 - name: Uniform1qps
   qpsLoad:
@@ -161,3 +162,4 @@ steps:
       action: gather
 {{end}}
 {{end}}
+

--- a/egw-scale-utils/test/config.yaml
+++ b/egw-scale-utils/test/config.yaml
@@ -1,5 +1,6 @@
 {{$NumEGWClients := DefaultParam .CL2_NUM_EGW_CLIENTS 9}}
 {{$QPS := DefaultParam .CL2_EGW_CLIENTS_QPS 3}}
+{{$ADDITIONAL_MEASUREMENT_MODULES := DefaultParam .CL2_ADDITIONAL_MEASUREMENT_MODULES nil}}
 
 name: egw-scale-test-masq-delay
 namespace:
@@ -51,6 +52,16 @@ steps:
       labelSelector: app.kubernetes.io/name=egw-client,scaffolding.cilium.io/egw-client-is-bootstrap=true
       desiredPodCount: 1
       timeout: 55s
+
+{{if $ADDITIONAL_MEASUREMENT_MODULES}}
+{{range $ADDITIONAL_MEASUREMENT_MODULES}}
+- module:
+    path: {{.}}
+    params:
+      action: start
+{{end}}
+{{end}}
+
 - name: Start measurements
   measurements:
   - Identifier: EGWMasqueradeDelayMetrics
@@ -141,3 +152,12 @@ steps:
     Method: GenericPrometheusQuery
     Params:
       action: gather
+
+{{if $ADDITIONAL_MEASUREMENT_MODULES}}
+{{range $ADDITIONAL_MEASUREMENT_MODULES}}
+- module:
+    path: {{.}}
+    params:
+      action: gather
+{{end}}
+{{end}}

--- a/egw-scale-utils/test/preflight.sh
+++ b/egw-scale-utils/test/preflight.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -xeo pipefail
 
-EGW_IMAGE_TAG=${EGW_IMAGE_TAG:-$(git rev-parse HEAD)}
+export EGW_IMAGE_TAG=${EGW_IMAGE_TAG:-$(git rev-parse HEAD)}
 
 fill_template() {
     echo $EGW_EXTERNAL_TARGET_CIDR


### PR DESCRIPTION
* `egw: add ADDITIONAL_MEASUREMENT_MODULES support to CL2 config`: Allows for additional measurement modules to be used, which is helpful in enabling profiling for cilium agents (see https://github.com/cilium/cilium/blob/main/.github/actions/cl2-modules/cilium-agent-pprofs.yaml)
* `egw: Add missing export to variable in preflight.sh`: Missing export caused incorrect image tag to be used in certain cases.
* `egw: Do not delete automated ns after test completion`: Only one ns is used, so cleanup is still simple to do. This helps with debugging.