### PR TITLE
egw-scale-utils: ensure consistent interval, and don't return on errors 

### DIFF
--- a/egw-scale-utils/Makefile
+++ b/egw-scale-utils/Makefile
@@ -1,5 +1,7 @@
 DOCKER_IMAGE ?= quay.io/cilium/egw-scale-utils:latest
 
+.PHONY: all docker-image docker-image-load docker-image-push egw-scale-utils local clean
+
 all: local
 
 docker-image:

--- a/egw-scale-utils/cmd/client.go
+++ b/egw-scale-utils/cmd/client.go
@@ -29,6 +29,9 @@ func init() {
 		&clientCfg.ExternalTargetAddr, "external-target-addr", "", "Address of external target to connect to. Needs to be of the format 'IP:Port'",
 	)
 	clientCmd.PersistentFlags().DurationVar(
+		&clientCfg.Interval, "interval", 50*time.Millisecond, "The interval at which the client sends probes to the server.",
+	)
+	clientCmd.PersistentFlags().DurationVar(
 		&clientCfg.TestTimeout, "test-timeout", time.Minute, "The duration the client has to connect to the external target before cancelling the test.",
 	)
 

--- a/egw-scale-utils/go.mod
+++ b/egw-scale-utils/go.mod
@@ -1,6 +1,6 @@
 module github.com/cilium/scaffolding/egw-scale-utils
 
-go 1.22.5
+go 1.24.0
 
 require (
 	github.com/prometheus/client_golang v1.20.5

--- a/egw-scale-utils/pkg/client.go
+++ b/egw-scale-utils/pkg/client.go
@@ -129,6 +129,7 @@ func connectToExternalTarget(
 
 func RunClient(cfg *ClientConfig) error {
 	logger := NewLogger("client").With("external-target", cfg.ExternalTargetAddr)
+	logger.Info("Starting")
 
 	testHasFinished := &atomic.Bool{}
 	testHasFinished.Store(false)


### PR DESCRIPTION
Modify the client loop to ensure that probes are sent evenly spread, with the desired interval (which is now configurable as a parameter), independently of the time spent establishing the connection or reading the data from it. Previously, instead, the fixed 50ms sleep could lead to skews, making results dependent on the actual network latency. Similarly, reading from the connection could block forever, as no deadline was explicitly set.

Additionally, let's change all connection errors to not be fatal, so that the client doesn't restart in case of timeouts. We were indeed observing this behavior in the actual tests (likely caused by SYN packets being dropped during datapath reconfiguration), partially invalidating the results. Errors are now instead treated as misses.