### PR TITLE
egw-scale-utils: parallel connections stress test

### DIFF
--- a/egw-scale-utils/README.md
+++ b/egw-scale-utils/README.md
@@ -76,3 +76,24 @@ each of the components in the test. The binary has two subcommands:
 |`egw_scale_test_leaked_requests_total`|The total number of leaked requests a client made when trying to access the external target.|
 |`egw_scale_test_masquerade_delay_seconds_total`|The number of seconds between a client pod starting and hitting the external target.|
 |`egw_scale_test_failed_tests_total`|Incremented when a client Pod is unable to connect to the external target after a preconfigured timeout.|
+
+## Max Parallel Connections
+
+This test measures the maximum number of parallel connections that can be opened
+from a client to an external destination via the egress gateway. Specifically,
+once the first connection is successfully established, the client continuously
+opens new connections until repeated failures are encountered. All connections
+are kept open by the server, and closed only when the client process gets terminated.
+
+This test leverages the same binary as the pod masquerade delay test. The
+`external-target` shall be passed the `--keep-open` flag to keep connections open.
+The client, instead, shall be passed the `--stress` flag to execute the parallel
+connections stress test; optionally, the `--stress-delay` flag may be also configured
+to introduce a delay before starting the test (for metrics scraping purposes).
+
+### Client Pod Metrics
+
+|Name|Description|
+|---|---|
+|`egw_scale_test_stress_connections_total`|The total number connections towards the external target. Labeled by *operation*, with possible values *open* (i.e., connections successfully opened) and *close* (i.e., connections unexpectedly closed).|
+|`egw_scale_test_stress_connection_latency_seconds`|The time that it takes for a new connection to be successfully opened|

--- a/egw-scale-utils/cmd/client.go
+++ b/egw-scale-utils/cmd/client.go
@@ -34,6 +34,12 @@ func init() {
 	clientCmd.PersistentFlags().DurationVar(
 		&clientCfg.TestTimeout, "test-timeout", time.Minute, "The duration the client has to connect to the external target before cancelling the test.",
 	)
+	clientCmd.PersistentFlags().BoolVar(
+		&clientCfg.Stress, "stress", false, "Keep opening connections to the external target until repeated failures occur.",
+	)
+	clientCmd.PersistentFlags().DurationVar(
+		&clientCfg.StressDelay, "stress-delay", 0, "Delay before starting the connections stress test, for metrics scraping purpose.",
+	)
 
 	rootCmd.AddCommand(clientCmd)
 }

--- a/egw-scale-utils/cmd/external-target.go
+++ b/egw-scale-utils/cmd/external-target.go
@@ -27,7 +27,11 @@ func init() {
 		&externalTargetCfg.AllowedCIDRString, "allowed-cidr", "", "Only respond to clients from the given CIDR",
 	)
 	externalTargetCmd.PersistentFlags().IntVar(
-		&externalTargetCfg.ListenPort, "listen-port", 1337, "Port to listen for incomming connections on",
+		&externalTargetCfg.ListenPort, "listen-port", 1337, "Port to listen for incoming connections on",
+	)
+
+	externalTargetCmd.PersistentFlags().BoolVar(
+		&externalTargetCfg.KeepOpen, "keep-open", false, "Keep incoming connections open until the client closes them",
 	)
 
 	rootCmd.AddCommand(externalTargetCmd)

--- a/egw-scale-utils/pkg/client.go
+++ b/egw-scale-utils/pkg/client.go
@@ -22,6 +22,8 @@ type ClientConfig struct {
 	ExternalTargetAddr string
 	Interval           time.Duration
 	TestTimeout        time.Duration
+	Stress             bool
+	StressDelay        time.Duration
 }
 
 var (
@@ -39,6 +41,16 @@ var (
 		Name: "egw_scale_test_failed_tests_total",
 		Help: "Incremented when a client Pod is unable to connect to the external target after a preconfigured timeout",
 	})
+
+	testStressConnectionsCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "egw_scale_test_stress_connections_total",
+		Help: "The number of connections either successfully opened or unexpectedly closed towards the external target",
+	}, []string{"operation"})
+
+	testStressConnectionLatency = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name: "egw_scale_test_stress_connection_latency_seconds",
+		Help: "The time that it takes for a new connection to be successfully opened",
+	})
 )
 
 func getHttpReadinessProbeHandler(testHasFinished *atomic.Bool) http.HandlerFunc {
@@ -49,6 +61,79 @@ func getHttpReadinessProbeHandler(testHasFinished *atomic.Bool) http.HandlerFunc
 			w.WriteHeader(500)
 		}
 	}
+}
+
+func stressExternalTarget(
+	cfg *ClientConfig,
+	testHasFinished *atomic.Bool,
+	logger *slog.Logger,
+) {
+	const (
+		dialTimeout = 5 * time.Second
+		readTimeout = 5 * time.Second
+		maxerrs     = 3
+	)
+
+	var (
+		count  uint32
+		errcnt uint32
+		dialer = net.Dialer{
+			Timeout: dialTimeout,
+			KeepAliveConfig: net.KeepAliveConfig{
+				Enable: true, Idle: 1 * time.Second,
+				Interval: 1 * time.Second, Count: 15,
+			},
+		}
+		limiter = NewLogLimiter[string]()
+	)
+
+	// Initialize the metric labels
+	testStressConnectionsCounter.WithLabelValues("open")
+	testStressConnectionsCounter.WithLabelValues("close")
+
+	logger.Info("Waiting before starting the connections stress test", "delay", cfg.StressDelay)
+	time.Sleep(cfg.StressDelay)
+
+	for errcnt < maxerrs {
+		start := time.Now()
+		conn, err := dialer.Dial("tcp4", cfg.ExternalTargetAddr)
+		elapsed := time.Since(start)
+
+		if err != nil {
+			errcnt++
+			logger.Warn("Failed to dial target", "err", err, "cnt", count, "errcnt", errcnt, "elapsed", elapsed)
+			continue
+		}
+
+		count++
+
+		testStressConnectionsCounter.WithLabelValues("open").Inc()
+		testStressConnectionLatency.Observe(elapsed.Seconds())
+
+		if _, can := limiter.CanLog("open"); can {
+			logger.Debug("Successfully dialed target", "cnt", count, "errcnt", errcnt)
+		}
+
+		if elapsed > 100*time.Millisecond {
+			logger.Warn("Dialing took more than 100ms", "cnt", count, "errcnt", errcnt, "elapsed", elapsed)
+		}
+
+		go func(conn net.Conn) {
+			// We never actually close the connections; they will be GCed when
+			// the client is closed.
+			err := readUntilError(conn)
+
+			if cnt, can := limiter.CanLog("close"); can {
+				logger.Error("Connection unexpectedly closed", "err", err, "cnt", cnt)
+			}
+
+			testStressConnectionsCounter.WithLabelValues("close").Inc()
+			conn.Close()
+		}(conn)
+	}
+
+	testHasFinished.Store(true)
+	logger.Info("Test completed", "cnt", count, "errcnt", errcnt)
 }
 
 func connectToExternalTarget(
@@ -124,12 +209,16 @@ func connectToExternalTarget(
 
 	masqueradeDelayCounter.Add(delay.Seconds())
 
+	if cfg.Stress {
+		stressExternalTarget(cfg, testHasFinished, logger)
+	}
+
 	return nil
 }
 
 func RunClient(cfg *ClientConfig) error {
 	logger := NewLogger("client").With("external-target", cfg.ExternalTargetAddr)
-	logger.Info("Starting")
+	logger.Info("Starting", "stress", cfg.Stress)
 
 	testHasFinished := &atomic.Bool{}
 	testHasFinished.Store(false)

--- a/egw-scale-utils/pkg/logging.go
+++ b/egw-scale-utils/pkg/logging.go
@@ -6,6 +6,7 @@ package pkg
 import (
 	"log/slog"
 	"os"
+	"sync"
 )
 
 func NewLogger(component string) *slog.Logger {
@@ -18,4 +19,23 @@ func NewLogger(component string) *slog.Logger {
 	)
 
 	return slog.New(handler).With("component", component)
+}
+
+type LogLimiter[K comparable] struct {
+	mu  sync.Mutex
+	cnt map[K]uint64
+}
+
+func NewLogLimiter[K comparable]() *LogLimiter[K] {
+	return &LogLimiter[K]{cnt: make(map[K]uint64)}
+}
+
+func (ll *LogLimiter[K]) CanLog(key K) (cnt uint64, can bool) {
+	ll.mu.Lock()
+	defer ll.mu.Unlock()
+
+	cnt = ll.cnt[key] + 1
+	ll.cnt[key] = cnt
+
+	return cnt, cnt <= 3 || cnt == 10 || cnt == 100 || cnt%1000 == 0
 }


### PR DESCRIPTION
Extend the egw-scale-utils with a new mode that allows to assess the maximum number of parallel connections that can be opened from a client to an external destination via the egress gateway. Specifically, once the first connection is successfully established, the client continuously opens new connections until repeated failures are encountered. All connections are kept open by the server, and closed only when the client process gets terminated.