### PR TITLE
perfdash: adapt egress gateway config to latest changes

### DIFF
--- a/scale-tests/jobs/egress-gateway.yaml
+++ b/scale-tests/jobs/egress-gateway.yaml
@@ -1,9 +1,9 @@
 periodics:
-- name: egw-md-bs-100-20-main
+- name: egw-baseline-100-20-main
   tags:
   - "perfDashPrefix: egw-baseline-main"
-  - "perfDashJobType: performance"
-- name: egw-md-100-20-main
+  - "perfDashJobType: networking"
+- name: egw-egw-100-20-main
   tags:
   - "perfDashPrefix: egw-main"
-  - "perfDashJobType: performance"
+  - "perfDashJobType: networking"


### PR DESCRIPTION
Align the bucket name, and change the type to additionally display the network performance results.