### PR TITLE
cmapisrv-mock: implement biased random walk to prevent resource drift

### DIFF
--- a/cmapisrv-mock/internal/mocker/cache.go
+++ b/cmapisrv-mock/internal/mocker/cache.go
@@ -26,11 +26,11 @@ func (c *cache[T]) Get(rnd *random) T {
 	return c.values[id]
 }
 
-func (c *cache[T]) AlmostEmpty() bool {
+func (c *cache[T]) Len() uint {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	return len(c.values) <= 3
+	return uint(len(c.values))
 }
 
 func (c *cache[T]) Add(value T) bool {

--- a/cmapisrv-mock/internal/mocker/endpoint.go
+++ b/cmapisrv-mock/internal/mocker/endpoint.go
@@ -57,15 +57,15 @@ func newEndpoints(
 	return eps
 }
 
-func (eps *endpoints) next(synced bool) (obj *identity.IPIdentityPair, delete bool) {
-	if synced && eps.rnd.ShouldUpdateUnlikely() && !eps.cache.AlmostEmpty() {
+func (eps *endpoints) next(synced bool, target uint) (obj *identity.IPIdentityPair, delete bool) {
+	if synced && eps.rnd.ShouldUpdateUnlikely() && eps.cache.Len() > 0 {
 		endpoint := eps.cache.Get(eps.rnd)
 		endpoint.ID = eps.identityGetter()
 		eps.cache.Upsert(endpoint)
 		return endpoint, false
 	}
 
-	if synced && eps.rnd.ShouldRemove() && !eps.cache.AlmostEmpty() {
+	if synced && eps.rnd.ShouldRemove(eps.cache.Len(), target) && eps.cache.Len() > 1 {
 		return eps.cache.Remove(eps.rnd), true
 	}
 

--- a/cmapisrv-mock/internal/mocker/identity.go
+++ b/cmapisrv-mock/internal/mocker/identity.go
@@ -47,8 +47,8 @@ func (ids *identities) RandomIdentity() identity.NumericIdentity {
 	return identity.NumericIdentity(parsed)
 }
 
-func (ids *identities) next(synced bool) (obj *store.KVPair, delete bool) {
-	if synced && ids.rnd.ShouldRemove() && !ids.cache.AlmostEmpty() {
+func (ids *identities) next(synced bool, target uint) (obj *store.KVPair, delete bool) {
+	if synced && ids.rnd.ShouldRemove(ids.cache.Len(), target) && ids.cache.Len() > 1 {
 		return ids.cache.Remove(ids.rnd), true
 	}
 

--- a/cmapisrv-mock/internal/mocker/node.go
+++ b/cmapisrv-mock/internal/mocker/node.go
@@ -51,8 +51,8 @@ func (ns *nodes) RandomHostIP() net.IP {
 	return no.GetNodeInternalIPv4()
 }
 
-func (ns *nodes) next(synced bool) (obj *nodeTypes.Node, delete bool) {
-	if synced && ns.rnd.ShouldRemove() && !ns.cache.AlmostEmpty() {
+func (ns *nodes) next(synced bool, target uint) (obj *nodeTypes.Node, delete bool) {
+	if synced && ns.rnd.ShouldRemove(ns.cache.Len(), target) && ns.cache.Len() > 1 {
 		return ns.cache.Remove(ns.rnd), true
 	}
 

--- a/cmapisrv-mock/internal/mocker/random.go
+++ b/cmapisrv-mock/internal/mocker/random.go
@@ -16,6 +16,8 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 )
 
+const MaxServiceBackends = 50
+
 type random struct {
 	nodeIP4, nodeIP6 addr
 	podIP4, podIP6   addr
@@ -68,7 +70,18 @@ func (r *random) CIDR6() *net.IPNet { return r.cidr6.Next() }
 func (r *random) Index(length int) int       { return rand.Intn(length) }
 func (r *random) ShouldUpdateUnlikely() bool { return rand.Intn(5) == 0 }
 func (r *random) ShouldUpdateLikely() bool   { return rand.Intn(100) != 0 }
-func (r *random) ShouldRemove() bool         { return rand.Intn(2) == 1 }
+
+// The probability of removing an object is current / (current + target).
+// This ensures that when current == target, the probability is 0.5.
+// When current > target, the probability is > 0.5, and when current < target,
+// it is < 0.5.
+func (r *random) ShouldRemove(current, target uint) bool {
+	if target == 0 {
+		return rand.Intn(2) == 1
+	}
+
+	return uint(rand.Intn(int(current+target))) < current
+}
 
 func (r *random) Identity(cluster uint32) identity.NumericIdentity {
 	return identity.NumericIdentity(cluster<<16 + uint32(rand.Intn(65536-256)+256))
@@ -91,7 +104,7 @@ func (r *random) IdentityLabels(cluster string) labels.LabelArray {
 	return lbls
 }
 
-func (r *random) ServiceBackends() int { return rand.Intn(50) }
+func (r *random) ServiceBackends() int { return rand.Intn(MaxServiceBackends) }
 func (r *random) ServiceLabels() map[string]string {
 	n := rand.Intn(6) + 1
 	lbls := make(map[string]string, n)

--- a/cmapisrv-mock/internal/mocker/service.go
+++ b/cmapisrv-mock/internal/mocker/service.go
@@ -40,15 +40,15 @@ func newServices(log *slog.Logger, cp cparams) *services {
 	return svc
 }
 
-func (svc *services) next(synced bool) (obj *serviceStore.ClusterService, delete bool) {
-	if synced && svc.rnd.ShouldUpdateLikely() && !svc.cache.AlmostEmpty() {
+func (svc *services) next(synced bool, target uint) (obj *serviceStore.ClusterService, delete bool) {
+	if synced && svc.rnd.ShouldUpdateLikely() && svc.cache.Len() > 0 {
 		service := svc.cache.Get(svc.rnd)
 		service.Backends = svc.updated(service.Backends)
 		svc.cache.Upsert(service)
 		return service, false
 	}
 
-	if synced && svc.rnd.ShouldRemove() && !svc.cache.AlmostEmpty() {
+	if synced && svc.rnd.ShouldRemove(svc.cache.Len(), target) && svc.cache.Len() > 1 {
 		return svc.cache.Remove(svc.rnd), true
 	}
 
@@ -114,7 +114,7 @@ func (svc *services) backends() map[string]serviceStore.PortConfiguration {
 }
 
 func (svc *services) updated(be map[string]serviceStore.PortConfiguration) map[string]serviceStore.PortConfiguration {
-	if svc.rnd.ShouldRemove() && len(be) > 0 {
+	if svc.rnd.ShouldRemove(uint(len(be)), uint(MaxServiceBackends/2)) && len(be) > 0 {
 		key := slices.Collect(maps.Keys(be))[svc.rnd.Index(len(be))]
 		delete(be, key)
 		return be

--- a/cmapisrv-mock/internal/mocker/syncer.go
+++ b/cmapisrv-mock/internal/mocker/syncer.go
@@ -15,7 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
-type nextFn[T store.Key] func(synced bool) (obj T, delete bool)
+type nextFn[T store.Key] func(synced bool, target uint) (obj T, delete bool)
 
 type syncer[T store.Key] struct {
 	log   *slog.Logger
@@ -60,7 +60,7 @@ func (s syncer[T]) Run(ctx context.Context, target uint, qps rate.Limit, allSync
 	}()
 
 	for i := uint(0); i < target; i++ {
-		do(s.next(false))
+		do(s.next(false, target))
 	}
 
 	s.store.Synced(ctx, func(context.Context) {
@@ -86,7 +86,7 @@ func (s syncer[T]) Run(ctx context.Context, target uint, qps rate.Limit, allSync
 		}
 
 		if target != 0 && qps > 0 {
-			do(s.next(true))
+			do(s.next(true, target))
 		}
 	}
 }


### PR DESCRIPTION
In the existing cmapisrv-mock mocker container, the number of mocked resources can drift significantly over time from the intended target specified in the flag.

Implement a mean-reverting random walk where the probability of removal is calculated as P(remove) = current / (current + target). This ensures that we remove an element with increasing probability as current grows further from target.

Fixes https://github.com/cilium/scaffolding/issues/282