### PR TITLE
renovate: additionally onboard toolkit go dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,7 +12,8 @@
     "cmapisrv-mock/go.*",
     "cmapisrv-mock/Dockerfile",
     "egw-scale-utils/go.*",
-    "egw-scale-utils/Dockerfile"
+    "egw-scale-utils/Dockerfile",
+    "toolkit/go.*",
   ],
   "pinDigests": true,
   "ignorePresets": [":prHourlyLimit2"],


### PR DESCRIPTION
Onboard the toolkit go dependencies to renovate, so that they are automatically kept up-to-date, and prevent them from being flagged by automated scanners.