### PR TITLE
renovate: don't attempt to pin golangci-lint digest

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -79,6 +79,16 @@
         '**/Dockerfile',
       ],
     },
+    {
+      // Prevent renovate from attempting to pin the golangci-lint digest.
+      matchManagers: [
+        'github-actions',
+      ],
+      matchPackageNames: [
+        'golangci/golangci-lint',
+      ],
+      pinDigests: false,
+    },
   ],
   customManagers: [
     {


### PR DESCRIPTION
For some reason, likely a renovate update, renovate started trying to pin the golangci-lint digest in the corresponding workflow, which is not correct, and causes the entire set of updates to fail. Let's get this fixed by explicitly disabling digest pinning for that dependency.