### PR TITLE
egw-scale-utils: bound the stress test by wall-clock duration

### DIFF
--- a/egw-scale-utils/cmd/client.go
+++ b/egw-scale-utils/cmd/client.go
@@ -40,6 +40,9 @@ func init() {
 	clientCmd.PersistentFlags().DurationVar(
 		&clientCfg.StressDelay, "stress-delay", 0, "Delay before starting the connections stress test, for metrics scraping purpose.",
 	)
+	clientCmd.PersistentFlags().DurationVar(
+		&clientCfg.StressDuration, "stress-duration", 0, "Maximum duration of the connections stress test. The test also stops early after repeated failures. Zero means no time bound (stop on failures only).",
+	)
 
 	rootCmd.AddCommand(clientCmd)
 }

--- a/egw-scale-utils/pkg/client.go
+++ b/egw-scale-utils/pkg/client.go
@@ -24,6 +24,7 @@ type ClientConfig struct {
 	TestTimeout        time.Duration
 	Stress             bool
 	StressDelay        time.Duration
+	StressDuration     time.Duration
 }
 
 var (
@@ -94,7 +95,22 @@ func stressExternalTarget(
 	logger.Info("Waiting before starting the connections stress test", "delay", cfg.StressDelay)
 	time.Sleep(cfg.StressDelay)
 
+	// A nil channel blocks forever, so when StressDuration is unset the loop
+	// remains bounded only by maxerrs, preserving the previous behavior.
+	var deadline <-chan time.Time
+	if cfg.StressDuration > 0 {
+		deadline = time.After(cfg.StressDuration)
+	}
+
+loop:
 	for errcnt < maxerrs {
+		select {
+		case <-deadline:
+			logger.Info("Stress duration elapsed, completing test", "duration", cfg.StressDuration, "cnt", count, "errcnt", errcnt)
+			break loop
+		default:
+		}
+
 		start := time.Now()
 		conn, err := dialer.Dial("tcp4", cfg.ExternalTargetAddr)
 		elapsed := time.Since(start)


### PR DESCRIPTION
The stress client marks itself ready only once its stress loop finishes, and that loop finishes only after three cumulative dial failures accrue, with no time bound. Under a datapath that is heavily loaded but otherwise healthy those failures are rare and sporadic, so the loop can keep running for well over fifteen minutes, and the client never reports ready in time for the WaitForRunningPods step on the cilium side. The coupling is backwards: a more broken datapath produces the three failures quickly and the pod turns ready fast, while a healthy one keeps the loop running until the caller times out. This is what has been failing the Scale Test Egress Gateway workflow on the stress-base client.

This adds a stress-duration flag that also bounds the loop by wall-clock time. The loop still exits early on repeated failures, so that signal is preserved, but a healthy run now completes deterministically once the duration elapses. The connection counts and latency histograms are still exported for Prometheus to scrape after the run, so a genuine egress gateway regression remains visible. Zero preserves the previous behaviour of stopping on failures only, so existing callers are unaffected.

The consuming side in cilium/cilium will pass the new flag from the CL2 stress-test module and bump egw_utils_ref to an image built from this change. That bump has to happen before the cilium side starts passing the flag, otherwise the client rejects the unknown flag at startup.

This change was prepared with AIL:3.